### PR TITLE
Add modular combat proc system

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,15 +57,12 @@
                             <span>Talent Bonus (%)</span>
                             <input type="number" id="talentBonus" min="0" value="30">
                         </label>
-                        <label>
-                            <span>Proc Chance (%)</span>
-                            <input type="number" id="procChance" min="0" max="100" value="15">
-                        </label>
-                        <label>
-                            <span>Proc Energy</span>
-                            <input type="number" id="procEnergy" min="0" value="25">
-                        </label>
                     </div>
+                </section>
+
+                <section class="panel-section">
+                    <h2>Combat Procs</h2>
+                    <div id="procConfig" class="proc-config"></div>
                 </section>
 
                 <section class="panel-section">
@@ -125,6 +122,7 @@
                             <div class="dummy-body"></div>
                             <div class="dummy-shadow"></div>
                         </div>
+                        <div class="floating-text-container" id="floatingTextContainer"></div>
                     </div>
 
                     <div class="resource-panel">

--- a/style.css
+++ b/style.css
@@ -109,6 +109,75 @@ body {
     border-color: rgba(255, 215, 0, 0.6);
 }
 
+.proc-config {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.proc-card {
+    background: rgba(18, 26, 48, 0.78);
+    border: 1px solid rgba(255, 215, 0, 0.12);
+    border-radius: 12px;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.proc-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+}
+
+.proc-header h3 {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.95rem;
+    color: #ffe589;
+    letter-spacing: 0.5px;
+}
+
+.proc-header label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.8rem;
+    color: #cbd4ff;
+    cursor: pointer;
+}
+
+.proc-description {
+    font-size: 0.75rem;
+    color: #9fb3ff;
+    line-height: 1.4;
+}
+
+.proc-fields {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+    gap: 10px;
+}
+
+.proc-fields label {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.75rem;
+    color: #9fb3ff;
+}
+
+.proc-fields input[type="number"] {
+    padding: 6px 8px;
+    border-radius: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.08);
+    color: #f1f4ff;
+}
+
 .build-controls {
     display: flex;
     flex-direction: column;
@@ -579,10 +648,67 @@ body {
     background: rgba(30, 42, 74, 0.78);
     border: 1px solid rgba(255, 215, 0, 0.1);
     font-size: 0.8rem;
+    gap: 8px;
 }
 
 .buff-row.debuff {
     background: rgba(122, 32, 32, 0.78);
+}
+
+.buff-row .buff-icon {
+    font-size: 1rem;
+}
+
+.buff-row .buff-name {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.floating-text-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    overflow: visible;
+}
+
+.floating-text {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 1rem;
+    color: #ffe17a;
+    font-weight: 600;
+    text-shadow: 0 0 10px rgba(0, 0, 0, 0.7);
+    animation: floatUp 1.2s ease-out forwards;
+    white-space: nowrap;
+}
+
+.floating-text.proc {
+    color: #a3f5ff;
+}
+
+.floating-text.energy {
+    color: #7cffb0;
+}
+
+@keyframes floatUp {
+    0% {
+        opacity: 0;
+        transform: translate(-50%, 10px);
+    }
+    15% {
+        opacity: 1;
+        transform: translate(-50%, 0);
+    }
+    100% {
+        opacity: 0;
+        transform: translate(-50%, -40px);
+    }
 }
 
 .rotation-coach {


### PR DESCRIPTION
## Summary
- add a modular proc system with five configurable procs and UI controls
- update combat logic to use shared stat modifiers and display proc feedback
- enhance styles with proc cards, floating text, and buff icons

## Testing
- node --check script.js

------
https://chatgpt.com/codex/tasks/task_e_68d593776e488329bd120470031dbc5a