### PR TITLE
Clear cooldowns when starting combat

### DIFF
--- a/script.js
+++ b/script.js
@@ -1137,6 +1137,7 @@ class RogueSimulator {
     startCombat() {
         if (this.state.inCombat) return;
         this.state.inCombat = true;
+        this.state.cooldowns.clear();
         this.state.stats.combatTime = 0;
         this.state.stats.totalDamage = 0;
         this.state.stats.hitCount = 0;


### PR DESCRIPTION
## Summary
- clear the simulator cooldown map when entering combat so new sessions begin fresh

## Testing
- manual testing in browser to confirm ability buttons no longer keep cooldown overlay after restart

------
https://chatgpt.com/codex/tasks/task_e_68d5a15e087883298b2528015fb00a39