### PR TITLE
Fix start combat button to reference bound simulator

### DIFF
--- a/script.js
+++ b/script.js
@@ -426,9 +426,9 @@ class UIController {
             const id = this.forms.buildSelect.value;
             simulator.deleteBuild(id);
         });
-        this.buttons.startCombat.addEventListener('click', () => simulator.startCombat());
-        this.buttons.stopCombat.addEventListener('click', () => simulator.stopCombat());
-        this.buttons.resetCombat.addEventListener('click', () => simulator.reset());
+        this.buttons.startCombat.addEventListener('click', () => this.simulator?.startCombat());
+        this.buttons.stopCombat.addEventListener('click', () => this.simulator?.stopCombat());
+        this.buttons.resetCombat.addEventListener('click', () => this.simulator?.reset());
     }
 
     getConfigFromInputs() {


### PR DESCRIPTION
## Summary
- ensure the combat control buttons invoke the currently bound simulator instance so Start Combat works after rebinding

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d64661db008329ab171bd4eb404fec