### PR TITLE
Add talent toggles and rotation sandbox customization

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,6 +66,42 @@
                 </section>
 
                 <section class="panel-section">
+                    <h2>Talent Lab</h2>
+                    <div class="talent-grid">
+                        <label class="talent-option">
+                            <input type="checkbox" id="talentPrecision">
+                            <span>
+                                <strong>Precision Strikes</strong>
+                                <small>+3% hit chance. Finishers gain +5% crit chance and deal 8% more damage.</small>
+                            </span>
+                        </label>
+                        <label class="talent-option">
+                            <input type="checkbox" id="talentRelentless">
+                            <span>
+                                <strong>Relentless Strikes</strong>
+                                <small>Spending combo points refunds energy based on points consumed.</small>
+                            </span>
+                        </label>
+                        <label class="talent-option">
+                            <input type="checkbox" id="talentShadowTechniques">
+                            <span>
+                                <strong>Shadow Techniques</strong>
+                                <small>Auto attacks have a 30% chance to grant 1 combo point.</small>
+                            </span>
+                        </label>
+                    </div>
+                </section>
+
+                <section class="panel-section">
+                    <h2>Rotation Sandbox</h2>
+                    <div class="rotation-config">
+                        <label for="rotationPriority" class="rotation-label">Priority List</label>
+                        <textarea id="rotationPriority" class="rotation-input" rows="4" placeholder="Example: sliceAndDice, rupture, envenom, backstab, sinisterStrike"></textarea>
+                        <p class="rotation-hint">Enter ability IDs or names separated by commas, arrows, or new lines to experiment with different priority systems.</p>
+                    </div>
+                </section>
+
+                <section class="panel-section">
                     <h2>Build Presets</h2>
                     <div class="build-controls">
                         <input type="text" id="buildName" placeholder="New build name">

--- a/style.css
+++ b/style.css
@@ -115,6 +115,80 @@ body {
     gap: 12px;
 }
 
+.talent-grid {
+    display: grid;
+    gap: 12px;
+}
+
+.talent-option {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 10px 12px;
+    border-radius: 10px;
+    background: rgba(19, 28, 52, 0.68);
+    border: 1px solid rgba(255, 215, 0, 0.12);
+    font-size: 0.85rem;
+    color: #d5ddff;
+}
+
+.talent-option input[type="checkbox"] {
+    width: 18px;
+    height: 18px;
+    accent-color: #ffda6a;
+    margin-top: 4px;
+}
+
+.talent-option strong {
+    display: block;
+    color: #ffe58d;
+    letter-spacing: 0.5px;
+    margin-bottom: 2px;
+}
+
+.talent-option small {
+    color: #a9b8ff;
+    font-size: 0.75rem;
+    line-height: 1.4;
+}
+
+.rotation-config {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.rotation-label {
+    font-size: 0.8rem;
+    color: #cdd5ff;
+    letter-spacing: 0.5px;
+}
+
+.rotation-input {
+    width: 100%;
+    min-height: 120px;
+    padding: 10px 12px;
+    border-radius: 10px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: rgba(14, 20, 40, 0.85);
+    color: #f4f6fb;
+    resize: vertical;
+    font-size: 0.85rem;
+}
+
+.rotation-input:focus {
+    outline: none;
+    border-color: rgba(255, 215, 0, 0.6);
+    box-shadow: 0 0 0 2px rgba(255, 215, 0, 0.12);
+}
+
+.rotation-hint {
+    font-size: 0.7rem;
+    color: #9fb3ff;
+    line-height: 1.4;
+}
+
 .proc-card {
     background: rgba(18, 26, 48, 0.78);
     border: 1px solid rgba(255, 215, 0, 0.12);
@@ -799,6 +873,10 @@ body {
 
 .floating-text.energy {
     color: #7cffb0;
+}
+
+.floating-text.combo {
+    color: #ff9dfc;
 }
 
 @keyframes floatUp {


### PR DESCRIPTION
## Summary
- add a Talent Lab section with styling to toggle sandboxed rogue talents
- implement talent effects for precision strikes, relentless energy refunds, and shadow combo point procs
- provide a rotation sandbox priority editor that feeds the rotation coach with player-defined priorities

## Testing
- not run (project has no automated test suite)


------
https://chatgpt.com/codex/tasks/task_e_68d65f601ac08329a373424eeb14b13a