### PR TITLE
refactor: add entity registry to ARPG mode

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -354,61 +354,69 @@ class ProcSystem {
     }
 }
 class UIController {
-    constructor() {
-        // Fix: Use non-null assertions and type casting for element lookups.
-        this.elements = {
-            dummyHealthBar: document.getElementById('dummyHealthBar'),
-            dummyHealthText: document.getElementById('dummyHealthText'),
-            dummyModel: document.getElementById('dummyModel'),
-            energyBar: document.getElementById('energyBar'),
-            energyText: document.getElementById('energyText'),
-            comboPoints: Array.from(document.querySelectorAll('#comboPoints .combo-point')),
-            buffTimers: document.getElementById('buffTimers'),
-            buffList: document.getElementById('buffList'),
-            debuffList: document.getElementById('debuffList'),
-            combatLog: document.getElementById('combatLog'),
-            actionBar: document.getElementById('actionBar'),
-            floatingTextContainer: document.getElementById('floatingTextContainer'),
-            currentDPS: document.getElementById('currentDPS'),
-            totalDamage: document.getElementById('totalDamage'),
-            averageDPS: document.getElementById('averageDPS'),
-            hitCount: document.getElementById('hitCount'),
-            critCount: document.getElementById('critCount'),
-            abilityBreakdownList: document.getElementById('abilityBreakdownList'),
-            forecast1: document.getElementById('forecast1'),
-            forecast3: document.getElementById('forecast3'),
-            forecast5: document.getElementById('forecast5'),
-            combatTimer: document.getElementById('combatTimer'),
-            previousDps: document.getElementById('previousDps'),
-            currentDpsCompare: document.getElementById('currentDpsCompare'),
-            dpsDelta: document.getElementById('dpsDelta'),
-            dpsGraph: document.getElementById('dpsGraph'),
+    constructor(options = {}) {
+        this.idPrefix = options.idPrefix ?? '';
+        const resolveId = (id) => (this.idPrefix ? `${this.idPrefix}-${id}` : id);
+        const requireElement = (id) => {
+            const element = document.getElementById(resolveId(id));
+            if (!element) {
+                throw new Error(`Missing UI element: ${resolveId(id)}`);
+            }
+            return element;
         };
-        this.tooltip = document.getElementById('tooltip');
+        this.elements = {
+            dummyHealthBar: requireElement('dummyHealthBar'),
+            dummyHealthText: requireElement('dummyHealthText'),
+            dummyModel: requireElement('dummyModel'),
+            energyBar: requireElement('energyBar'),
+            energyText: requireElement('energyText'),
+            comboPoints: Array.from(requireElement('comboPoints').querySelectorAll('.combo-point')),
+            buffTimers: requireElement('buffTimers'),
+            buffList: requireElement('buffList'),
+            debuffList: requireElement('debuffList'),
+            combatLog: requireElement('combatLog'),
+            actionBar: requireElement('actionBar'),
+            floatingTextContainer: requireElement('floatingTextContainer'),
+            currentDPS: requireElement('currentDPS'),
+            totalDamage: requireElement('totalDamage'),
+            averageDPS: requireElement('averageDPS'),
+            hitCount: requireElement('hitCount'),
+            critCount: requireElement('critCount'),
+            abilityBreakdownList: requireElement('abilityBreakdownList'),
+            forecast1: requireElement('forecast1'),
+            forecast3: requireElement('forecast3'),
+            forecast5: requireElement('forecast5'),
+            combatTimer: requireElement('combatTimer'),
+            previousDps: requireElement('previousDps'),
+            currentDpsCompare: requireElement('currentDpsCompare'),
+            dpsDelta: requireElement('dpsDelta'),
+            dpsGraph: requireElement('dpsGraph'),
+        };
+        this.tooltip = requireElement('tooltip');
         this.forms = {
-            attackPower: document.getElementById('attackPower'),
-            weaponMin: document.getElementById('weaponMin'),
-            weaponMax: document.getElementById('weaponMax'),
-            critChance: document.getElementById('critChance'),
-            hitChance: document.getElementById('hitChance'),
-            maxEnergy: document.getElementById('maxEnergy'),
-            tickInterval: document.getElementById('tickInterval'),
-            energyPerTick: document.getElementById('energyPerTick'),
-            talentBonus: document.getElementById('talentBonus'),
-            talentPrecision: document.getElementById('talentPrecision'),
-            talentRelentless: document.getElementById('talentRelentless'),
-            talentShadowTechniques: document.getElementById('talentShadowTechniques'),
+            attackPower: requireElement('attackPower'),
+            weaponMin: requireElement('weaponMin'),
+            weaponMax: requireElement('weaponMax'),
+            critChance: requireElement('critChance'),
+            hitChance: requireElement('hitChance'),
+            maxEnergy: requireElement('maxEnergy'),
+            tickInterval: requireElement('tickInterval'),
+            energyPerTick: requireElement('energyPerTick'),
+            talentBonus: requireElement('talentBonus'),
+            talentPrecision: requireElement('talentPrecision'),
+            talentRelentless: requireElement('talentRelentless'),
+            talentShadowTechniques: requireElement('talentShadowTechniques'),
         };
         this.buttons = {
-            startCombat: document.getElementById('startCombat'),
-            stopCombat: document.getElementById('stopCombat'),
-            resetCombat: document.getElementById('resetCombat'),
+            startCombat: requireElement('startCombat'),
+            stopCombat: requireElement('stopCombat'),
+            resetCombat: requireElement('resetCombat'),
         };
-        /** @type {RogueSimulator | null} */
         this.simulator = null;
         this.soundPlayer = new SoundPlayer();
         this.procInputs = new Map();
-        this.procConfigContainer = document.getElementById('procConfig');
+        this.procConfigContainer = requireElement('procConfig');
+        this.abilityInterceptor = null;
     }
     bindSimulator(simulator) {
         // Fix: Simplify formInputs creation, as this.forms only contains input elements.
@@ -517,11 +525,23 @@ class UIController {
                 <span>${ability.icon}</span>
                 <span class="ability-hotkey">${ability.hotkey}</span>
             `;
-            button.addEventListener('click', () => this.simulator?.castAbility(ability.id));
+            button.addEventListener('click', () => this.useAbility(ability.id));
             button.addEventListener('mouseenter', (event) => this.showTooltip(event, ability));
             button.addEventListener('mouseleave', () => this.hideTooltip());
             this.elements.actionBar.appendChild(button);
         });
+    }
+    setAbilityInterceptor(handler) {
+        this.abilityInterceptor = handler;
+    }
+    useAbility(abilityId) {
+        if (this.abilityInterceptor) {
+            const result = this.abilityInterceptor(abilityId);
+            if (result === false) {
+                return;
+            }
+        }
+        this.simulator?.castAbility(abilityId);
     }
     showTooltip(event, ability) {
         const { currentTarget } = event;
@@ -852,7 +872,9 @@ class UIController {
         this.hotkeyMap = map;
     }
     attachHotkeyListeners() {
-        document.addEventListener('keydown', (event) => {
+        if (this.keyHandler)
+            return;
+        this.keyHandler = (event) => {
             if (event.repeat)
                 return;
             const target = event.target;
@@ -872,14 +894,708 @@ class UIController {
             const abilityId = this.hotkeyMap?.get(event.key.toLowerCase());
             if (abilityId) {
                 event.preventDefault();
-                this.simulator?.castAbility(abilityId);
+                this.useAbility(abilityId);
+            }
+        };
+        document.addEventListener('keydown', this.keyHandler);
+    }
+    detachHotkeyListeners() {
+        if (!this.keyHandler)
+            return;
+        document.removeEventListener('keydown', this.keyHandler);
+        this.keyHandler = undefined;
+    }
+}
+class ActionRpgUIController extends UIController {
+    constructor() {
+        super({ idPrefix: 'arpg' });
+        this.game = null;
+        this.minimapCanvas = document.getElementById('arpg-minimap');
+        this.minimapCtx = this.minimapCanvas ? this.minimapCanvas.getContext('2d') : null;
+        this.targetName = document.getElementById('arpg-targetName');
+        this.targetFrame = document.getElementById('arpg-targetFrame');
+        this.rangeWarning = document.getElementById('arpg-rangeWarning');
+        this.playerBuffContainer = document.getElementById('arpg-playerBuffs');
+        this.dpsMeterValue = document.getElementById('arpg-currentDPS');
+        this.worldProjector = null;
+        this.combatLogWindow = document.getElementById('arpg-combatLogWindow');
+        this.combatLogHandle = document.getElementById('arpg-combatLogHandle');
+        this.dragState = { active: false, offsetX: 0, offsetY: 0 };
+        this.enableDrag();
+    }
+    setGame(game) {
+        this.game = game;
+    }
+    setWorldProjector(projector) {
+        this.worldProjector = projector;
+    }
+    getMinimapContext() {
+        return this.minimapCtx;
+    }
+    updateActionBarPosition(x, y) {
+        const bar = this.elements.actionBar;
+        bar.style.left = `${x}px`;
+        bar.style.top = `${y}px`;
+    }
+    updateTargetFrame(info) {
+        if (!info) {
+            this.targetFrame.classList.add('hidden');
+            this.targetName.textContent = 'No Target';
+            return;
+        }
+        this.targetFrame.classList.remove('hidden');
+        this.targetName.textContent = info.name;
+    }
+    showRangeWarning(message) {
+        if (!message) {
+            this.rangeWarning.classList.remove('visible');
+            this.rangeWarning.textContent = '';
+        }
+        else {
+            this.rangeWarning.classList.add('visible');
+            this.rangeWarning.textContent = message;
+        }
+    }
+    updateDpsMeter(value) {
+        this.dpsMeterValue.textContent = value.toFixed(1);
+    }
+    updateBuffTimers(buffValues, debuffValues) {
+        super.updateBuffTimers(buffValues, debuffValues);
+        const container = this.playerBuffContainer;
+        container.innerHTML = '';
+        [...buffValues, ...debuffValues].forEach(effect => {
+            const node = document.createElement('div');
+            node.className = `player-buff ${effect.type === 'debuff' ? 'debuff' : ''}`;
+            node.textContent = `${effect.icon ?? ''}`;
+            node.title = `${effect.name} (${effect.remaining.toFixed(1)}s)`;
+            container.appendChild(node);
+        });
+    }
+    flashDummy() {
+        this.soundPlayer.playHit();
+        this.game?.flashTarget();
+    }
+    showDamageNumber(damage, { isCrit = false, isAuto = false }) {
+        const container = this.elements.floatingTextContainer;
+        if (!container)
+            return;
+        const node = document.createElement('div');
+        node.className = 'damage-number anchored';
+        if (isCrit)
+            node.classList.add('crit');
+        if (isAuto)
+            node.classList.add('auto');
+        node.textContent = String(Math.floor(damage));
+        const anchor = this.worldProjector?.('target');
+        if (anchor) {
+            node.style.left = `${anchor.x}px`;
+            node.style.top = `${anchor.y}px`;
+        }
+        container.appendChild(node);
+        setTimeout(() => node.remove(), 1600);
+    }
+    showFloatingText(message, type = 'proc') {
+        const container = this.elements.floatingTextContainer;
+        if (!container)
+            return;
+        const node = document.createElement('div');
+        node.className = `floating-text anchored ${type}`;
+        node.textContent = message;
+        const anchor = this.worldProjector?.('player');
+        if (anchor) {
+            node.style.left = `${anchor.x}px`;
+            node.style.top = `${anchor.y}px`;
+        }
+        container.appendChild(node);
+        setTimeout(() => node.remove(), 1200);
+    }
+    updateResources(state) {
+        super.updateResources(state);
+        this.updateDpsMeter(this.game ? this.game.getCurrentDps() : 0);
+    }
+    enableDrag() {
+        if (!this.combatLogWindow || !this.combatLogHandle)
+            return;
+        const windowEl = this.combatLogWindow;
+        const handle = this.combatLogHandle;
+        const onMouseMove = (event) => {
+            if (!this.dragState.active)
+                return;
+            windowEl.style.left = `${event.clientX - this.dragState.offsetX}px`;
+            windowEl.style.top = `${event.clientY - this.dragState.offsetY}px`;
+        };
+        const onMouseUp = () => {
+            this.dragState.active = false;
+            document.removeEventListener('mousemove', onMouseMove);
+            document.removeEventListener('mouseup', onMouseUp);
+        };
+        handle.addEventListener('mousedown', (event) => {
+            this.dragState.active = true;
+            const rect = windowEl.getBoundingClientRect();
+            this.dragState.offsetX = event.clientX - rect.left;
+            this.dragState.offsetY = event.clientY - rect.top;
+            document.addEventListener('mousemove', onMouseMove);
+            document.addEventListener('mouseup', onMouseUp);
+        });
+    }
+}
+class EntityCollection {
+    constructor(initial) {
+        this.items = new Map();
+        initial?.forEach(entity => this.add(entity));
+    }
+    add(entity) {
+        this.items.set(entity.id, entity);
+    }
+    remove(id) {
+        this.items.delete(id);
+    }
+    getById(id) {
+        return this.items.get(id) ?? null;
+    }
+    first(predicate) {
+        if (!predicate) {
+            for (const entity of this.items.values()) {
+                return entity;
+            }
+            return null;
+        }
+        for (const entity of this.items.values()) {
+            if (predicate(entity)) {
+                return entity;
+            }
+        }
+        return null;
+    }
+    forEach(callback) {
+        this.items.forEach(entity => callback(entity));
+    }
+    map(callback) {
+        return Array.from(this.items.values(), callback);
+    }
+    filter(predicate) {
+        const results = [];
+        this.items.forEach(entity => {
+            if (predicate(entity)) {
+                results.push(entity);
             }
         });
+        return results;
+    }
+    find(predicate) {
+        for (const entity of this.items.values()) {
+            if (predicate(entity)) {
+                return entity;
+            }
+        }
+        return null;
+    }
+    toArray() {
+        return Array.from(this.items.values());
+    }
+    get size() {
+        return this.items.size;
+    }
+    [Symbol.iterator]() {
+        return this.items.values();
+    }
+}
+class ActionRpgGame {
+    constructor(canvas, ui, simulator) {
+        this.tick = (timestamp) => {
+            if (!this.running)
+                return;
+            const delta = (timestamp - this.lastTimestamp) / 1000;
+            this.lastTimestamp = timestamp;
+            this.update(delta);
+            this.render();
+            this.loopHandle = requestAnimationFrame(this.tick);
+        };
+        this.onKeyDown = (event) => {
+            if (event.repeat)
+                return;
+            if (event.code === 'Tab') {
+                event.preventDefault();
+                this.cycleTarget();
+                return;
+            }
+            if (event.code === 'KeyX') {
+                this.toggleStealth();
+                return;
+            }
+            this.keys.add(event.code);
+        };
+        this.onKeyUp = (event) => {
+            this.keys.delete(event.code);
+        };
+        this.onClick = (event) => {
+            const rect = this.canvas.getBoundingClientRect();
+            const x = event.clientX - rect.left;
+            const y = event.clientY - rect.top;
+            const world = this.screenToWorld(x, y);
+            const clicked = this.dummies.find(dummy => Math.hypot(dummy.x - world.x, dummy.y - world.y) <= dummy.radius + 6);
+            if (clicked) {
+                this.selectTarget(clicked);
+            }
+            else {
+                this.selectTarget(null);
+            }
+        };
+        const ctx = canvas.getContext('2d');
+        if (!ctx) {
+            throw new Error('Canvas 2D context unavailable for ARPG mode');
+        }
+        this.canvas = canvas;
+        this.ctx = ctx;
+        this.ui = ui;
+        this.simulator = simulator;
+        this.tileSize = 64;
+        this.map = this.createMap();
+        this.keys = new Set();
+        this.player = {
+            x: this.tileSize * 3,
+            y: this.tileSize * 3,
+            width: 42,
+            height: 56,
+            baseSpeed: 160,
+            sprintSpeed: 240,
+            animationTimer: 0,
+            animationFrame: 0,
+            facing: 'right',
+            stealth: false,
+        };
+        this.camera = { x: this.player.x, y: this.player.y };
+        this.dummies = new EntityCollection(this.createDummies());
+        this.adapters = new Map();
+        this.currentTarget = this.dummies.first() ?? null;
+        this.meleeRange = 110;
+        this.running = false;
+        this.loopHandle = null;
+        this.lastTimestamp = performance.now();
+        this.sprintEnergyCost = 18;
+        this.ui.setGame(this);
+        this.ui.setWorldProjector((entity) => this.getAnchor(entity));
+        this.ui.setAbilityInterceptor((abilityId) => this.handleAbilityIntercept(abilityId));
+        this.ui.updateTargetFrame(this.currentTarget ? this.getTargetInfo(this.currentTarget) : null);
+        if (this.currentTarget) {
+            this.simulator.setExternalTarget(this.getAdapter(this.currentTarget));
+        }
+    }
+    getCurrentDps() {
+        return this.simulator.getCurrentDps();
+    }
+    start() {
+        if (this.running)
+            return;
+        this.running = true;
+        this.bindInput();
+        this.lastTimestamp = performance.now();
+        this.loopHandle = requestAnimationFrame(this.tick);
+    }
+    stop() {
+        if (!this.running)
+            return;
+        this.running = false;
+        if (this.loopHandle !== null) {
+            cancelAnimationFrame(this.loopHandle);
+            this.loopHandle = null;
+        }
+        this.unbindInput();
+    }
+    destroy() {
+        this.stop();
+        this.ui.setAbilityInterceptor(null);
+        this.ui.setWorldProjector(null);
+    }
+    update(delta) {
+        this.updatePlayer(delta);
+        this.updateDummies(delta);
+        this.updateCamera();
+        this.updateActionBar();
+        this.drawMinimap();
+    }
+    updatePlayer(delta) {
+        const speed = this.getMovementSpeed(delta);
+        let moveX = 0;
+        let moveY = 0;
+        if (this.keys.has('KeyW'))
+            moveY -= 1;
+        if (this.keys.has('KeyS'))
+            moveY += 1;
+        if (this.keys.has('KeyA')) {
+            moveX -= 1;
+            this.player.facing = 'left';
+        }
+        if (this.keys.has('KeyD')) {
+            moveX += 1;
+            this.player.facing = 'right';
+        }
+        const magnitude = Math.hypot(moveX, moveY);
+        if (magnitude > 0) {
+            moveX /= magnitude;
+            moveY /= magnitude;
+            this.player.animationTimer += delta;
+            if (this.player.animationTimer >= 0.15) {
+                this.player.animationTimer = 0;
+                this.player.animationFrame = (this.player.animationFrame + 1) % 2;
+            }
+        }
+        else {
+            this.player.animationFrame = 0;
+            this.player.animationTimer = 0;
+        }
+        this.tryMove(moveX * speed * delta, moveY * speed * delta);
+    }
+    getMovementSpeed(delta) {
+        const sprinting = this.keys.has('ShiftLeft') || this.keys.has('ShiftRight');
+        if (sprinting && this.simulator.state.energy > 0) {
+            const cost = this.sprintEnergyCost * delta;
+            this.simulator.spendEnergy(cost);
+            return this.player.sprintSpeed;
+        }
+        return this.player.baseSpeed;
+    }
+    tryMove(dx, dy) {
+        const nextX = this.player.x + dx;
+        const nextY = this.player.y + dy;
+        if (this.isWalkable(nextX, this.player.y, this.player.width, this.player.height)) {
+            this.player.x = nextX;
+        }
+        if (this.isWalkable(this.player.x, nextY, this.player.width, this.player.height)) {
+            this.player.y = nextY;
+        }
+    }
+    isWalkable(x, y, width, height) {
+        const halfW = width / 2;
+        const halfH = height / 2;
+        const bounds = [
+            { x: x - halfW, y: y - halfH },
+            { x: x + halfW, y: y - halfH },
+            { x: x - halfW, y: y + halfH },
+            { x: x + halfW, y: y + halfH },
+        ];
+        return bounds.every(point => this.isTileWalkable(point.x, point.y));
+    }
+    isTileWalkable(x, y) {
+        if (x < 0 || y < 0)
+            return false;
+        const tileX = Math.floor(x / this.tileSize);
+        const tileY = Math.floor(y / this.tileSize);
+        if (tileY < 0 || tileY >= this.map.length)
+            return false;
+        if (tileX < 0 || tileX >= this.map[0].length)
+            return false;
+        const tile = this.map[tileY][tileX];
+        return tile !== 2;
+    }
+    updateDummies(delta) {
+        this.dummies.forEach(dummy => {
+            if (dummy.health <= 0) {
+                dummy.respawnTimer -= delta;
+                if (dummy.respawnTimer <= 0) {
+                    dummy.health = dummy.maxHealth;
+                    dummy.respawnTimer = 0;
+                    if (dummy === this.currentTarget) {
+                        this.simulator.setExternalTarget(this.getAdapter(dummy));
+                    }
+                }
+            }
+            if (dummy.highlight > 0) {
+                dummy.highlight = Math.max(0, dummy.highlight - delta * 3);
+            }
+        });
+    }
+    updateCamera() {
+        const halfWidth = this.canvas.width / 2;
+        const halfHeight = this.canvas.height / 2;
+        const mapWidth = this.map[0].length * this.tileSize;
+        const mapHeight = this.map.length * this.tileSize;
+        const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+        this.camera.x = clamp(this.player.x, halfWidth, mapWidth - halfWidth);
+        this.camera.y = clamp(this.player.y, halfHeight, mapHeight - halfHeight);
+    }
+    updateActionBar() {
+        const playerScreen = this.worldToScreen(this.player.x, this.player.y);
+        this.ui.updateActionBarPosition(playerScreen.x - 160, playerScreen.y + 60);
+    }
+    drawMinimap() {
+        const ctx = this.ui.getMinimapContext();
+        const canvas = this.ui.minimapCanvas;
+        if (!ctx || !canvas)
+            return;
+        const scaleX = canvas.width / (this.map[0].length * this.tileSize);
+        const scaleY = canvas.height / (this.map.length * this.tileSize);
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.fillStyle = '#1f1f24';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        this.map.forEach((row, y) => {
+            row.forEach((tile, x) => {
+                if (tile === 2) {
+                    ctx.fillStyle = '#2c2f3a';
+                }
+                else if (tile === 1) {
+                    ctx.fillStyle = '#1b412f';
+                }
+                else {
+                    ctx.fillStyle = '#304a73';
+                }
+                ctx.fillRect(x * this.tileSize * scaleX, y * this.tileSize * scaleY, this.tileSize * scaleX, this.tileSize * scaleY);
+            });
+        });
+        ctx.fillStyle = '#ffd166';
+        ctx.beginPath();
+        ctx.arc(this.player.x * scaleX, this.player.y * scaleY, 6, 0, Math.PI * 2);
+        ctx.fill();
+        this.dummies.forEach(dummy => {
+            ctx.fillStyle = dummy === this.currentTarget ? '#ef476f' : '#06d6a0';
+            ctx.beginPath();
+            ctx.arc(dummy.x * scaleX, dummy.y * scaleY, 5, 0, Math.PI * 2);
+            ctx.fill();
+        });
+    }
+    render() {
+        this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+        this.drawTiles();
+        this.drawDummies();
+        this.drawPlayer();
+    }
+    drawTiles() {
+        for (let y = 0; y < this.map.length; y++) {
+            for (let x = 0; x < this.map[y].length; x++) {
+                const tile = this.map[y][x];
+                const screen = this.worldToScreen((x + 0.5) * this.tileSize, (y + 0.5) * this.tileSize);
+                const drawX = screen.x - this.tileSize / 2;
+                const drawY = screen.y - this.tileSize / 2;
+                if (tile === 2) {
+                    this.ctx.fillStyle = '#1d1e26';
+                }
+                else if (tile === 1) {
+                    this.ctx.fillStyle = '#283845';
+                }
+                else {
+                    this.ctx.fillStyle = '#1f2933';
+                }
+                this.ctx.fillRect(drawX, drawY, this.tileSize, this.tileSize);
+            }
+        }
+    }
+    drawDummies() {
+        this.dummies.forEach(dummy => {
+            const screen = this.worldToScreen(dummy.x, dummy.y);
+            const radius = dummy.radius;
+            if (dummy.health <= 0) {
+                this.ctx.globalAlpha = 0.35;
+            }
+            this.ctx.fillStyle = '#7c4dff';
+            this.ctx.beginPath();
+            this.ctx.arc(screen.x, screen.y, radius, 0, Math.PI * 2);
+            this.ctx.fill();
+            if (dummy.highlight > 0) {
+                this.ctx.strokeStyle = `rgba(255,255,255,${dummy.highlight})`;
+                this.ctx.lineWidth = 4;
+                this.ctx.beginPath();
+                this.ctx.arc(screen.x, screen.y, radius + 4, 0, Math.PI * 2);
+                this.ctx.stroke();
+            }
+            this.ctx.globalAlpha = 1;
+            // HP bar
+            const barWidth = radius * 2;
+            const barHeight = 6;
+            const healthPercent = Math.max(0, dummy.health / dummy.maxHealth);
+            this.ctx.fillStyle = '#1f1f1f';
+            this.ctx.fillRect(screen.x - radius, screen.y - radius - 16, barWidth, barHeight);
+            this.ctx.fillStyle = '#06d6a0';
+            this.ctx.fillRect(screen.x - radius, screen.y - radius - 16, barWidth * healthPercent, barHeight);
+            if (dummy === this.currentTarget) {
+                this.ctx.strokeStyle = '#ffd166';
+                this.ctx.lineWidth = 2;
+                this.ctx.strokeRect(screen.x - radius - 4, screen.y - radius - 20, barWidth + 8, barHeight + 8);
+            }
+        });
+    }
+    drawPlayer() {
+        const screen = this.worldToScreen(this.player.x, this.player.y);
+        this.ctx.save();
+        if (this.player.stealth) {
+            this.ctx.globalAlpha = 0.55;
+        }
+        this.ctx.translate(screen.x, screen.y);
+        if (this.player.facing === 'left') {
+            this.ctx.scale(-1, 1);
+        }
+        this.ctx.fillStyle = '#ef476f';
+        const frameOffset = this.player.animationFrame === 0 ? 0 : 4;
+        this.ctx.fillRect(-this.player.width / 2, -this.player.height / 2 - frameOffset, this.player.width, this.player.height);
+        this.ctx.fillStyle = '#ffd166';
+        this.ctx.fillRect(-8, -this.player.height / 2 - frameOffset - 6, 16, 16);
+        this.ctx.restore();
+        this.ctx.globalAlpha = 1;
+    }
+    flashTarget() {
+        if (!this.currentTarget)
+            return;
+        this.currentTarget.highlight = 1;
+    }
+    createMap() {
+        const rows = 18;
+        const cols = 24;
+        const layout = [];
+        for (let y = 0; y < rows; y++) {
+            const row = [];
+            for (let x = 0; x < cols; x++) {
+                if (x === 0 || y === 0 || x === cols - 1 || y === rows - 1) {
+                    row.push(2); // wall
+                }
+                else {
+                    row.push(0);
+                }
+            }
+            layout.push(row);
+        }
+        // Create simple rooms and corridors
+        const carveRoom = (startX, startY, w, h) => {
+            for (let y = startY; y < startY + h; y++) {
+                for (let x = startX; x < startX + w; x++) {
+                    if (x > 0 && y > 0 && x < cols - 1 && y < rows - 1) {
+                        layout[y][x] = 1;
+                    }
+                }
+            }
+        };
+        carveRoom(2, 2, 7, 6);
+        carveRoom(10, 2, 8, 6);
+        carveRoom(5, 10, 12, 6);
+        // Corridors
+        for (let x = 7; x < 17; x++)
+            layout[7][x] = 1;
+        for (let y = 7; y < 13; y++)
+            layout[y][7] = 1;
+        return layout;
+    }
+    createDummies() {
+        return [
+            { kind: 'dummy', id: 'dummy-1', name: 'Training Dummy Alpha', x: this.tileSize * 4, y: this.tileSize * 4, radius: 24, maxHealth: 15000, health: 15000, respawnTimer: 0, highlight: 0 },
+            { kind: 'dummy', id: 'dummy-2', name: 'Training Dummy Beta', x: this.tileSize * 12, y: this.tileSize * 4, radius: 24, maxHealth: 20000, health: 20000, respawnTimer: 0, highlight: 0 },
+            { kind: 'dummy', id: 'dummy-3', name: 'Training Dummy Gamma', x: this.tileSize * 9, y: this.tileSize * 12, radius: 24, maxHealth: 25000, health: 25000, respawnTimer: 0, highlight: 0 },
+        ];
+    }
+    bindInput() {
+        window.addEventListener('keydown', this.onKeyDown);
+        window.addEventListener('keyup', this.onKeyUp);
+        this.canvas.addEventListener('click', this.onClick);
+    }
+    unbindInput() {
+        window.removeEventListener('keydown', this.onKeyDown);
+        window.removeEventListener('keyup', this.onKeyUp);
+        this.canvas.removeEventListener('click', this.onClick);
+    }
+    toggleStealth() {
+        this.player.stealth = !this.player.stealth;
+        if (this.player.stealth) {
+            this.simulator.applyBuff({ id: 'stealth', name: 'Stealth', duration: Infinity, icon: '🕶️', type: 'buff' });
+        }
+        else {
+            this.simulator.removeBuff('stealth');
+        }
+    }
+    cycleTarget() {
+        if (this.dummies.size === 0)
+            return;
+        const alive = this.dummies.filter(dummy => dummy.health > 0);
+        if (alive.length === 0)
+            return;
+        const currentId = this.currentTarget?.id;
+        const currentIndex = currentId ? alive.findIndex(dummy => dummy.id === currentId) : 0;
+        const next = alive[(currentIndex + 1) % alive.length];
+        this.selectTarget(next);
+    }
+    selectTarget(dummy) {
+        this.currentTarget = dummy;
+        if (dummy) {
+            this.simulator.setExternalTarget(this.getAdapter(dummy));
+            this.ui.updateTargetFrame(this.getTargetInfo(dummy));
+        }
+        else {
+            this.simulator.stopCombat();
+            this.simulator.setExternalTarget(null);
+            this.ui.updateTargetFrame(null);
+        }
+        this.ui.showRangeWarning('');
+    }
+    handleAbilityIntercept(_abilityId) {
+        if (!this.currentTarget) {
+            this.ui.showRangeWarning('Kein Ziel ausgewählt');
+            return false;
+        }
+        if (this.currentTarget.health <= 0) {
+            this.ui.showRangeWarning('Ziel ist besiegt');
+            return false;
+        }
+        const distance = Math.hypot(this.player.x - this.currentTarget.x, this.player.y - this.currentTarget.y);
+        if (distance > this.meleeRange) {
+            this.ui.showRangeWarning('Außer Reichweite');
+            return false;
+        }
+        this.ui.showRangeWarning('');
+        return true;
+    }
+    getAdapter(dummy) {
+        let adapter = this.adapters.get(dummy.id);
+        if (!adapter) {
+            adapter = {
+                getCurrentHealth: () => dummy.health,
+                getMaxHealth: () => dummy.maxHealth,
+                applyDamage: (amount) => {
+                    dummy.health = Math.max(0, dummy.health - amount);
+                    dummy.highlight = 1;
+                    if (dummy.health <= 0) {
+                        dummy.respawnTimer = 5;
+                    }
+                },
+                onCombatStart: () => { },
+                onCombatEnd: () => { },
+                onReset: () => {
+                    dummy.health = dummy.maxHealth;
+                    dummy.respawnTimer = 0;
+                },
+                onDefeated: () => { },
+            };
+            this.adapters.set(dummy.id, adapter);
+        }
+        return adapter;
+    }
+    getTargetInfo(dummy) {
+        return { id: dummy.id, name: dummy.name, health: dummy.health, maxHealth: dummy.maxHealth };
+    }
+    getAnchor(entity) {
+        if (entity === 'player') {
+            const pos = this.worldToScreen(this.player.x, this.player.y - this.player.height / 2);
+            return { x: pos.x, y: pos.y - 40 };
+        }
+        if (entity === 'target' && this.currentTarget) {
+            const pos = this.worldToScreen(this.currentTarget.x, this.currentTarget.y - this.currentTarget.radius - 10);
+            return { x: pos.x, y: pos.y };
+        }
+        return null;
+    }
+    worldToScreen(x, y) {
+        return {
+            x: Math.round((x - this.camera.x) + this.canvas.width / 2),
+            y: Math.round((y - this.camera.y) + this.canvas.height / 2),
+        };
+    }
+    screenToWorld(x, y) {
+        return {
+            x: this.camera.x - this.canvas.width / 2 + x,
+            y: this.camera.y - this.canvas.height / 2 + y,
+        };
     }
 }
 class RogueSimulator {
     constructor(ui) {
         this.ui = ui;
+        this.externalTarget = null;
+        this.defaultDummyHealth = 1000000;
         this.state = {
             inCombat: false,
             energy: 100,
@@ -887,8 +1603,8 @@ class RogueSimulator {
             comboPoints: 0,
             maxComboPoints: 5,
             globalCooldown: 0,
-            dummyMaxHealth: 1000000,
-            dummyHealth: 1000000,
+            dummyMaxHealth: this.defaultDummyHealth,
+            dummyHealth: this.defaultDummyHealth,
             autoAttackTimer: 2,
             baseAutoSpeed: 2,
             energyTickProgress: 0,
@@ -930,7 +1646,18 @@ class RogueSimulator {
         this.sessionHistory = [];
         this.currentSession = null;
         this.previousSession = null;
-        this.startLoop();
+        this.resume();
+    }
+    setExternalTarget(target) {
+        this.externalTarget = target;
+        if (target) {
+            this.state.dummyMaxHealth = target.getMaxHealth();
+            this.state.dummyHealth = target.getCurrentHealth();
+        }
+        else {
+            this.state.dummyMaxHealth = this.defaultDummyHealth;
+            this.state.dummyHealth = this.defaultDummyHealth;
+        }
     }
     getDefaultConfig() {
         return {
@@ -1273,6 +2000,18 @@ class RogueSimulator {
         };
         this.loopHandle = requestAnimationFrame(loop);
     }
+    pause() {
+        if (this.loopHandle !== null) {
+            cancelAnimationFrame(this.loopHandle);
+            this.loopHandle = null;
+        }
+    }
+    resume() {
+        if (this.loopHandle !== null)
+            return;
+        this.lastTimestamp = performance.now();
+        this.startLoop();
+    }
     update(delta) {
         let remaining = Math.max(delta, 0);
         const maxStep = 0.5;
@@ -1336,7 +2075,14 @@ class RogueSimulator {
         this.state.stats.dpsHistory = [];
         this.state.comboPoints = 0;
         this.state.energy = this.state.maxEnergy;
-        this.state.dummyHealth = this.state.dummyMaxHealth;
+        if (this.externalTarget) {
+            this.externalTarget.onCombatStart?.();
+            this.state.dummyMaxHealth = this.externalTarget.getMaxHealth();
+            this.state.dummyHealth = this.externalTarget.getCurrentHealth();
+        }
+        else {
+            this.state.dummyHealth = this.state.dummyMaxHealth;
+        }
         this.state.autoAttackTimer = this.state.baseAutoSpeed;
         this.state.energyTickProgress = 0;
         this.ui.addLogEntry('Combat started!', 'system');
@@ -1347,6 +2093,7 @@ class RogueSimulator {
         this.state.inCombat = false;
         this.state.globalCooldown = 0;
         this.clearEffects();
+        this.externalTarget?.onCombatEnd?.();
         const session = {
             damage: this.state.stats.totalDamage,
             duration: Math.max(this.state.stats.combatTime, 1),
@@ -1356,13 +2103,23 @@ class RogueSimulator {
         this.currentSession = session;
         this.sessionHistory.push(session);
         this.ui.addLogEntry('Combat ended.', 'system');
+        if (!this.externalTarget) {
+            this.state.dummyHealth = this.state.dummyMaxHealth;
+        }
     }
     reset() {
         this.state.inCombat = false;
         this.state.energy = this.state.maxEnergy;
         this.state.comboPoints = 0;
         this.state.globalCooldown = 0;
-        this.state.dummyHealth = this.state.dummyMaxHealth;
+        if (this.externalTarget) {
+            this.externalTarget.onReset?.();
+            this.state.dummyMaxHealth = this.externalTarget.getMaxHealth();
+            this.state.dummyHealth = this.externalTarget.getCurrentHealth();
+        }
+        else {
+            this.state.dummyHealth = this.state.dummyMaxHealth;
+        }
         this.state.autoAttackTimer = this.state.baseAutoSpeed;
         this.state.energyTickProgress = 0;
         this.clearEffects();
@@ -1500,7 +2257,14 @@ class RogueSimulator {
         const damage = Math.round(amount);
         if (damage <= 0)
             return;
-        this.state.dummyHealth = Math.max(0, this.state.dummyHealth - damage);
+        if (this.externalTarget) {
+            this.externalTarget.applyDamage(damage, { ability, isCrit, isAuto, isDot });
+            this.state.dummyMaxHealth = this.externalTarget.getMaxHealth();
+            this.state.dummyHealth = Math.max(0, this.externalTarget.getCurrentHealth());
+        }
+        else {
+            this.state.dummyHealth = Math.max(0, this.state.dummyHealth - damage);
+        }
         this.state.stats.totalDamage += damage;
         this.state.stats.hitCount += 1;
         if (isCrit)
@@ -1519,9 +2283,16 @@ class RogueSimulator {
         }
         this.procSystem.handleEvent('damage', { ability, isCrit, isAuto, isDot, damage });
         if (this.state.dummyHealth <= 0) {
-            this.ui.addLogEntry('Dummy defeated!', 'system');
-            this.stopCombat();
-            this.state.dummyHealth = this.state.dummyMaxHealth;
+            if (this.externalTarget) {
+                this.ui.addLogEntry('Target defeated!', 'system');
+                this.externalTarget.onDefeated?.();
+                this.stopCombat();
+            }
+            else {
+                this.ui.addLogEntry('Dummy defeated!', 'system');
+                this.stopCombat();
+                this.state.dummyHealth = this.state.dummyMaxHealth;
+            }
         }
     }
     incrementAbilityUsage(ability, damage) {
@@ -1630,6 +2401,13 @@ class RogueSimulator {
         this.state.buffs.set(buff.id, enriched);
         enriched.onApply?.();
     }
+    removeBuff(id) {
+        const existing = this.state.buffs.get(id);
+        if (existing) {
+            existing.onExpire?.();
+            this.state.buffs.delete(id);
+        }
+    }
     applyDebuff(debuff) {
         if (this.state.debuffs.has(debuff.id)) {
             this.state.debuffs.get(debuff.id).onExpire?.();
@@ -1673,6 +2451,62 @@ class RogueSimulator {
         return base * this.getEnergyRegenMultiplier();
     }
 }
-const ui = new UIController();
-const simulator = new RogueSimulator(ui);
-ui.bindSimulator(simulator);
+const simulatorUi = new UIController();
+const simulator = new RogueSimulator(simulatorUi);
+simulatorUi.bindSimulator(simulator);
+const arpgUi = new ActionRpgUIController();
+const arpgSimulator = new RogueSimulator(arpgUi);
+arpgUi.bindSimulator(arpgSimulator);
+arpgSimulator.pause();
+arpgUi.detachHotkeyListeners();
+const arpgCanvas = document.getElementById('arpg-canvas');
+const arpgGame = new ActionRpgGame(arpgCanvas, arpgUi, arpgSimulator);
+arpgGame.stop();
+const modeButtons = {
+    simulator: document.getElementById('switchSimulator'),
+    arpg: document.getElementById('switchArpg'),
+};
+const simulatorMode = document.getElementById('simulatorMode');
+const arpgMode = document.getElementById('arpgMode');
+let activeMode = 'simulator';
+function setActiveMode(mode) {
+    if (mode === activeMode)
+        return;
+    if (mode === 'simulator') {
+        document.body.classList.remove('mode-arpg');
+        document.body.classList.add('mode-simulator');
+        simulatorMode.classList.add('active');
+        arpgMode.classList.remove('active');
+        modeButtons.simulator.classList.add('active');
+        modeButtons.arpg.classList.remove('active');
+        arpgGame.stop();
+        arpgSimulator.removeBuff('stealth');
+        arpgGame.player.stealth = false;
+        arpgSimulator.pause();
+        arpgUi.detachHotkeyListeners();
+        arpgUi.showRangeWarning('');
+        simulator.resume();
+        simulatorUi.attachHotkeyListeners();
+    }
+    else {
+        document.body.classList.remove('mode-simulator');
+        document.body.classList.add('mode-arpg');
+        simulatorMode.classList.remove('active');
+        arpgMode.classList.add('active');
+        modeButtons.simulator.classList.remove('active');
+        modeButtons.arpg.classList.add('active');
+        simulator.pause();
+        simulatorUi.detachHotkeyListeners();
+        arpgSimulator.resume();
+        arpgUi.attachHotkeyListeners();
+        arpgGame.start();
+    }
+    activeMode = mode;
+}
+modeButtons.simulator.addEventListener('click', () => setActiveMode('simulator'));
+modeButtons.arpg.addEventListener('click', () => setActiveMode('arpg'));
+document.body.classList.add('mode-simulator');
+simulatorMode.classList.add('active');
+arpgMode.classList.remove('active');
+modeButtons.simulator.classList.add('active');
+modeButtons.arpg.classList.remove('active');

--- a/index.html
+++ b/index.html
@@ -20,233 +20,463 @@
             <p>Optimize your rotation, track buffs, and perfect your DPS uptime.</p>
         </header>
 
-        <div class="game-layout">
-            <!-- Left Panel: Configuration -->
-            <aside class="panel configuration-panel">
-                <section class="panel-section">
-                    <h2>Character Stats</h2>
-                    <form id="statsForm" class="form-grid">
-                        <label>
-                            <span>Attack Power</span>
-                            <input type="number" id="attackPower" min="0" value="1200">
-                        </label>
-                        <label>
-                            <span>Weapon Damage Min</span>
-                            <input type="number" id="weaponMin" min="0" value="150">
-                        </label>
-                        <label>
-                            <span>Weapon Damage Max</span>
-                            <input type="number" id="weaponMax" min="0" value="220">
-                        </label>
-                        <label>
-                            <span>Crit Chance (%)</span>
-                            <input type="number" id="critChance" min="0" max="100" value="25">
-                        </label>
-                        <label>
-                            <span>Hit Chance (%)</span>
-                            <input type="number" id="hitChance" min="0" max="100" value="95">
-                        </label>
-                    </form>
-                </section>
+        <div class="mode-switcher">
+            <button id="switchSimulator" class="mode-button active">DPS Simulator</button>
+            <button id="switchArpg" class="mode-button">Action RPG</button>
+        </div>
 
-                <section class="panel-section">
-                    <h2>Energy Regeneration</h2>
-                    <div class="form-grid">
-                        <label>
-                            <span>Max Energy</span>
-                            <input type="number" id="maxEnergy" min="100" max="250" value="100">
-                        </label>
-                        <label>
-                            <span>Tick Interval (ms)</span>
-                            <input type="number" id="tickInterval" min="100" value="2000">
-                        </label>
-                        <label>
-                            <span>Energy per Tick</span>
-                            <input type="number" id="energyPerTick" min="0" value="20">
-                        </label>
-                        <label>
-                            <span>Talent Bonus (%)</span>
-                            <input type="number" id="talentBonus" min="0" value="30">
-                        </label>
-                    </div>
-                </section>
+        <div id="simulatorMode" class="mode-view active">
+            <div class="game-layout">
+                <!-- Left Panel: Configuration -->
+                <aside class="panel configuration-panel">
+                    <section class="panel-section">
+                        <h2>Character Stats</h2>
+                        <form id="statsForm" class="form-grid">
+                            <label>
+                                <span>Attack Power</span>
+                                <input type="number" id="attackPower" min="0" value="1200">
+                            </label>
+                            <label>
+                                <span>Weapon Damage Min</span>
+                                <input type="number" id="weaponMin" min="0" value="150">
+                            </label>
+                            <label>
+                                <span>Weapon Damage Max</span>
+                                <input type="number" id="weaponMax" min="0" value="220">
+                            </label>
+                            <label>
+                                <span>Crit Chance (%)</span>
+                                <input type="number" id="critChance" min="0" max="100" value="25">
+                            </label>
+                            <label>
+                                <span>Hit Chance (%)</span>
+                                <input type="number" id="hitChance" min="0" max="100" value="95">
+                            </label>
+                        </form>
+                    </section>
 
-                <section class="panel-section">
-                    <h2>Combat Procs</h2>
-                    <div id="procConfig" class="proc-config"></div>
-                </section>
+                    <section class="panel-section">
+                        <h2>Energy Regeneration</h2>
+                        <div class="form-grid">
+                            <label>
+                                <span>Max Energy</span>
+                                <input type="number" id="maxEnergy" min="100" max="250" value="100">
+                            </label>
+                            <label>
+                                <span>Tick Interval (ms)</span>
+                                <input type="number" id="tickInterval" min="100" value="2000">
+                            </label>
+                            <label>
+                                <span>Energy per Tick</span>
+                                <input type="number" id="energyPerTick" min="0" value="20">
+                            </label>
+                            <label>
+                                <span>Talent Bonus (%)</span>
+                                <input type="number" id="talentBonus" min="0" value="30">
+                            </label>
+                        </div>
+                    </section>
 
-                <section class="panel-section">
-                    <h2>Talent Lab</h2>
-                    <div class="talent-grid">
-                        <label class="talent-option">
-                            <input type="checkbox" id="talentPrecision">
-                            <span>
-                                <strong>Precision Strikes</strong>
-                                <small>+3% hit chance. Finishers gain +5% crit chance and deal 8% more damage.</small>
-                            </span>
-                        </label>
-                        <label class="talent-option">
-                            <input type="checkbox" id="talentRelentless">
-                            <span>
-                                <strong>Relentless Strikes</strong>
-                                <small>Spending combo points refunds energy based on points consumed.</small>
-                            </span>
-                        </label>
-                        <label class="talent-option">
-                            <input type="checkbox" id="talentShadowTechniques">
-                            <span>
-                                <strong>Shadow Techniques</strong>
-                                <small>Auto attacks have a 30% chance to grant 1 combo point.</small>
-                            </span>
-                        </label>
-                    </div>
-                </section>
+                    <section class="panel-section">
+                        <h2>Combat Procs</h2>
+                        <div id="procConfig" class="proc-config"></div>
+                    </section>
 
-                <section class="panel-section">
-                    <h2>Combat Control</h2>
-                    <div class="control-buttons">
-                        <button type="button" id="startCombat" class="primary">Start Combat</button>
-                        <button type="button" id="stopCombat">Stop Combat</button>
-                        <button type="button" id="resetCombat">Reset</button>
-                    </div>
-                    <div class="combat-timer">
-                        <span>Combat Time:</span>
-                        <strong id="combatTimer">0:00</strong>
-                    </div>
-                    <div class="session-compare">
-                        <h3>Session Comparison</h3>
-                        <div class="session-card">
+                    <section class="panel-section">
+                        <h2>Talent Lab</h2>
+                        <div class="talent-grid">
+                            <label class="talent-option">
+                                <input type="checkbox" id="talentPrecision">
+                                <span>
+                                    <strong>Precision Strikes</strong>
+                                    <small>+3% hit chance. Finishers gain +5% crit chance and deal 8% more damage.</small>
+                                </span>
+                            </label>
+                            <label class="talent-option">
+                                <input type="checkbox" id="talentRelentless">
+                                <span>
+                                    <strong>Relentless Strikes</strong>
+                                    <small>Spending combo points refunds energy based on points consumed.</small>
+                                </span>
+                            </label>
+                            <label class="talent-option">
+                                <input type="checkbox" id="talentShadowTechniques">
+                                <span>
+                                    <strong>Shadow Techniques</strong>
+                                    <small>Auto attacks have a 30% chance to grant 1 combo point.</small>
+                                </span>
+                            </label>
+                        </div>
+                    </section>
+
+                    <section class="panel-section">
+                        <h2>Combat Control</h2>
+                        <div class="control-buttons">
+                            <button type="button" id="startCombat" class="primary">Start Combat</button>
+                            <button type="button" id="stopCombat">Stop Combat</button>
+                            <button type="button" id="resetCombat">Reset</button>
+                        </div>
+                        <div class="combat-timer">
+                            <span>Combat Time:</span>
+                            <strong id="combatTimer">0:00</strong>
+                        </div>
+                        <div class="session-compare">
+                            <h3>Session Comparison</h3>
+                            <div class="session-card">
+                                <div>
+                                    <span class="label">Previous DPS</span>
+                                    <span id="previousDps">-</span>
+                                </div>
+                                <div>
+                                    <span class="label">Current DPS</span>
+                                    <span id="currentDpsCompare">-</span>
+                                </div>
+                                <div>
+                                    <span class="label">Delta</span>
+                                    <span id="dpsDelta">-</span>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+                </aside>
+
+                <!-- Center Panel: Combat -->
+                <main class="panel combat-panel">
+                    <section class="combat-stage">
+                        <div class="dummy-container">
+                            <div class="dummy-health">
+                                <div class="dummy-health-bar" id="dummyHealthBar"></div>
+                                <span class="dummy-health-text" id="dummyHealthText">100%</span>
+                            </div>
+                            <div class="dummy-model" id="dummyModel">
+                                <div class="dummy-head"></div>
+                                <div class="dummy-body"></div>
+                                <div class="dummy-shadow"></div>
+                            </div>
+                            <div class="floating-text-container" id="floatingTextContainer"></div>
+                        </div>
+
+                        <div class="resource-panel">
+                            <div class="energy-bar-container">
+                                <div class="energy-bar" id="energyBar"></div>
+                                <span class="energy-text" id="energyText">100 / 100</span>
+                            </div>
+                            <div class="combo-points" id="comboPoints">
+                                <span class="combo-point"></span>
+                                <span class="combo-point"></span>
+                                <span class="combo-point"></span>
+                                <span class="combo-point"></span>
+                                <span class="combo-point"></span>
+                            </div>
+                            <div class="buff-timers" id="buffTimers"></div>
+                            <div class="energy-forecast" id="energyForecast">
+                                <h3>Energy Forecast</h3>
+                                <div class="forecast-grid">
+                                    <div>
+                                        <span class="label">+1s</span>
+                                        <span class="value" id="forecast1">0</span>
+                                    </div>
+                                    <div>
+                                        <span class="label">+3s</span>
+                                        <span class="value" id="forecast3">0</span>
+                                    </div>
+                                    <div>
+                                        <span class="label">+5s</span>
+                                        <span class="value" id="forecast5">0</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section class="toolbar" id="actionBar"></section>
+
+                    <section class="combat-log-section">
+                        <h2>Combat Log</h2>
+                        <div class="combat-log" id="combatLog"></div>
+                    </section>
+                </main>
+
+                <!-- Right Panel: Analytics -->
+                <aside class="panel analytics-panel">
+                    <section class="panel-section">
+                        <h2>Live DPS</h2>
+                        <div class="dps-display">
+                            <span id="currentDPS">0</span>
+                            <small>Damage per second</small>
+                        </div>
+                        <canvas id="dpsGraph" width="280" height="160"></canvas>
+                    </section>
+
+                    <section class="panel-section">
+                        <h2>Statistics</h2>
+                        <div class="stats-grid">
                             <div>
-                                <span class="label">Previous DPS</span>
-                                <span id="previousDps">-</span>
+                                <span class="label">Total Damage</span>
+                                <span id="totalDamage">0</span>
                             </div>
                             <div>
-                                <span class="label">Current DPS</span>
-                                <span id="currentDpsCompare">-</span>
+                                <span class="label">Average DPS</span>
+                                <span id="averageDPS">0</span>
                             </div>
                             <div>
-                                <span class="label">Delta</span>
-                                <span id="dpsDelta">-</span>
+                                <span class="label">Hits</span>
+                                <span id="hitCount">0</span>
+                            </div>
+                            <div>
+                                <span class="label">Crits</span>
+                                <span id="critCount">0</span>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section class="panel-section">
+                        <h2>Ability Breakdown</h2>
+                        <div class="ability-breakdown">
+                            <div class="breakdown-header">
+                                <span>Ability</span>
+                                <span>Uses</span>
+                                <span>Damage</span>
+                                <span>Share</span>
+                            </div>
+                            <div id="abilityBreakdownList" class="breakdown-list"></div>
+                        </div>
+                    </section>
+
+                    <section class="panel-section">
+                        <h2>Buffs & Debuffs</h2>
+                        <div class="buff-list" id="buffList"></div>
+                        <div class="debuff-list" id="debuffList"></div>
+                    </section>
+                </aside>
+            </div>
+        </div>
+
+        <div id="arpgMode" class="mode-view">
+            <div class="arpg-container">
+                <div class="arpg-main">
+                    <div class="arpg-world">
+                        <div class="arpg-canvas-wrapper">
+                            <canvas id="arpg-canvas" width="960" height="600"></canvas>
+                            <div class="arpg-overlay">
+                                <div class="floating-text-container" id="arpg-floatingTextContainer"></div>
+                                <div class="arpg-player-hud">
+                                    <div class="energy-bar-container">
+                                        <div class="energy-bar" id="arpg-energyBar"></div>
+                                        <span class="energy-text" id="arpg-energyText">100 / 100</span>
+                                    </div>
+                                    <div class="combo-points" id="arpg-comboPoints">
+                                        <span class="combo-point"></span>
+                                        <span class="combo-point"></span>
+                                        <span class="combo-point"></span>
+                                        <span class="combo-point"></span>
+                                        <span class="combo-point"></span>
+                                    </div>
+                                    <div class="player-buff-icons" id="arpg-playerBuffs"></div>
+                                </div>
+                                <div class="arpg-target-frame" id="arpg-targetFrame">
+                                    <div class="dummy-model" id="arpg-dummyModel"></div>
+                                    <h3 id="arpg-targetName">No Target</h3>
+                                    <div class="dummy-health">
+                                        <div class="dummy-health-bar" id="arpg-dummyHealthBar"></div>
+                                        <span class="dummy-health-text" id="arpg-dummyHealthText">100%</span>
+                                    </div>
+                                    <div class="buff-timers" id="arpg-buffTimers"></div>
+                                </div>
+                                <div class="arpg-range-warning" id="arpg-rangeWarning"></div>
+                                <canvas id="arpg-minimap" width="180" height="180"></canvas>
+                                <section class="toolbar arpg-action-bar" id="arpg-actionBar"></section>
                             </div>
                         </div>
                     </div>
-                </section>
-            </aside>
-
-            <!-- Center Panel: Combat -->
-            <main class="panel combat-panel">
-                <section class="combat-stage">
-                    <div class="dummy-container">
-                        <div class="dummy-health">
-                            <div class="dummy-health-bar" id="dummyHealthBar"></div>
-                            <span class="dummy-health-text" id="dummyHealthText">100%</span>
-                        </div>
-                        <div class="dummy-model" id="dummyModel">
-                            <div class="dummy-head"></div>
-                            <div class="dummy-body"></div>
-                            <div class="dummy-shadow"></div>
-                        </div>
-                        <div class="floating-text-container" id="floatingTextContainer"></div>
-                    </div>
-
-                    <div class="resource-panel">
-                        <div class="energy-bar-container">
-                            <div class="energy-bar" id="energyBar"></div>
-                            <span class="energy-text" id="energyText">100 / 100</span>
-                        </div>
-                        <div class="combo-points" id="comboPoints">
-                            <span class="combo-point"></span>
-                            <span class="combo-point"></span>
-                            <span class="combo-point"></span>
-                            <span class="combo-point"></span>
-                            <span class="combo-point"></span>
-                        </div>
-                        <div class="buff-timers" id="buffTimers"></div>
-                        <div class="energy-forecast" id="energyForecast">
-                            <h3>Energy Forecast</h3>
+                    <aside class="panel arpg-info-panel">
+                        <section class="panel-section">
+                            <h2>Live DPS</h2>
+                            <div class="dps-display">
+                                <span id="arpg-currentDPS">0</span>
+                                <small>Damage per second</small>
+                            </div>
+                            <canvas id="arpg-dpsGraph" width="280" height="160"></canvas>
+                        </section>
+                        <section class="panel-section">
+                            <h2>Statistics</h2>
+                            <div class="stats-grid">
+                                <div>
+                                    <span class="label">Total Damage</span>
+                                    <span id="arpg-totalDamage">0</span>
+                                </div>
+                                <div>
+                                    <span class="label">Average DPS</span>
+                                    <span id="arpg-averageDPS">0</span>
+                                </div>
+                                <div>
+                                    <span class="label">Hits</span>
+                                    <span id="arpg-hitCount">0</span>
+                                </div>
+                                <div>
+                                    <span class="label">Crits</span>
+                                    <span id="arpg-critCount">0</span>
+                                </div>
+                            </div>
+                        </section>
+                        <section class="panel-section">
+                            <h2>Energy Forecast</h2>
                             <div class="forecast-grid">
                                 <div>
                                     <span class="label">+1s</span>
-                                    <span class="value" id="forecast1">0</span>
+                                    <span class="value" id="arpg-forecast1">0</span>
                                 </div>
                                 <div>
                                     <span class="label">+3s</span>
-                                    <span class="value" id="forecast3">0</span>
+                                    <span class="value" id="arpg-forecast3">0</span>
                                 </div>
                                 <div>
                                     <span class="label">+5s</span>
-                                    <span class="value" id="forecast5">0</span>
+                                    <span class="value" id="arpg-forecast5">0</span>
                                 </div>
                             </div>
+                        </section>
+                        <section class="panel-section">
+                            <h2>Ability Breakdown</h2>
+                            <div class="ability-breakdown">
+                                <div class="breakdown-header">
+                                    <span>Ability</span>
+                                    <span>Uses</span>
+                                    <span>Damage</span>
+                                    <span>Share</span>
+                                </div>
+                                <div id="arpg-abilityBreakdownList" class="breakdown-list"></div>
+                            </div>
+                        </section>
+                        <section class="panel-section">
+                            <h2>Buffs & Debuffs</h2>
+                            <div class="buff-list" id="arpg-buffList"></div>
+                            <div class="debuff-list" id="arpg-debuffList"></div>
+                        </section>
+                        <section class="panel-section">
+                            <h2>Session Overview</h2>
+                            <div class="session-compare">
+                                <div>
+                                    <span class="label">Previous DPS</span>
+                                    <span id="arpg-previousDps">-</span>
+                                </div>
+                                <div>
+                                    <span class="label">Current DPS</span>
+                                    <span id="arpg-currentDpsCompare">-</span>
+                                </div>
+                                <div>
+                                    <span class="label">Delta</span>
+                                    <span id="arpg-dpsDelta">-</span>
+                                </div>
+                            </div>
+                            <div class="combat-timer">
+                                <span>Combat Time:</span>
+                                <strong id="arpg-combatTimer">0:00</strong>
+                            </div>
+                        </section>
+                    </aside>
+                </div>
+                <aside class="panel arpg-config-panel">
+                    <section class="panel-section">
+                        <h2>Character Stats</h2>
+                        <div class="form-grid">
+                            <label>
+                                <span>Attack Power</span>
+                                <input type="number" id="arpg-attackPower" min="0" value="1200">
+                            </label>
+                            <label>
+                                <span>Weapon Damage Min</span>
+                                <input type="number" id="arpg-weaponMin" min="0" value="150">
+                            </label>
+                            <label>
+                                <span>Weapon Damage Max</span>
+                                <input type="number" id="arpg-weaponMax" min="0" value="220">
+                            </label>
+                            <label>
+                                <span>Crit Chance (%)</span>
+                                <input type="number" id="arpg-critChance" min="0" max="100" value="25">
+                            </label>
+                            <label>
+                                <span>Hit Chance (%)</span>
+                                <input type="number" id="arpg-hitChance" min="0" max="100" value="95">
+                            </label>
                         </div>
-                    </div>
-                </section>
-
-                <section class="toolbar" id="actionBar"></section>
-
-                <section class="combat-log-section">
-                    <h2>Combat Log</h2>
-                    <div class="combat-log" id="combatLog"></div>
-                </section>
-            </main>
-
-            <!-- Right Panel: Analytics -->
-            <aside class="panel analytics-panel">
-                <section class="panel-section">
-                    <h2>Live DPS</h2>
-                    <div class="dps-display">
-                        <span id="currentDPS">0</span>
-                        <small>Damage per second</small>
-                    </div>
-                    <canvas id="dpsGraph" width="280" height="160"></canvas>
-                </section>
-
-                <section class="panel-section">
-                    <h2>Statistics</h2>
-                    <div class="stats-grid">
-                        <div>
-                            <span class="label">Total Damage</span>
-                            <span id="totalDamage">0</span>
+                    </section>
+                    <section class="panel-section">
+                        <h2>Energy Regeneration</h2>
+                        <div class="form-grid">
+                            <label>
+                                <span>Max Energy</span>
+                                <input type="number" id="arpg-maxEnergy" min="100" max="250" value="100">
+                            </label>
+                            <label>
+                                <span>Tick Interval (ms)</span>
+                                <input type="number" id="arpg-tickInterval" min="100" value="2000">
+                            </label>
+                            <label>
+                                <span>Energy per Tick</span>
+                                <input type="number" id="arpg-energyPerTick" min="0" value="20">
+                            </label>
+                            <label>
+                                <span>Talent Bonus (%)</span>
+                                <input type="number" id="arpg-talentBonus" min="0" value="30">
+                            </label>
                         </div>
-                        <div>
-                            <span class="label">Average DPS</span>
-                            <span id="averageDPS">0</span>
+                    </section>
+                    <section class="panel-section">
+                        <h2>Talent Lab</h2>
+                        <div class="talent-grid">
+                            <label class="talent-option">
+                                <input type="checkbox" id="arpg-talentPrecision">
+                                <span>
+                                    <strong>Precision Strikes</strong>
+                                    <small>+3% hit chance. Finishers gain +5% crit chance and deal 8% more damage.</small>
+                                </span>
+                            </label>
+                            <label class="talent-option">
+                                <input type="checkbox" id="arpg-talentRelentless">
+                                <span>
+                                    <strong>Relentless Strikes</strong>
+                                    <small>Spending combo points refunds energy based on points consumed.</small>
+                                </span>
+                            </label>
+                            <label class="talent-option">
+                                <input type="checkbox" id="arpg-talentShadowTechniques">
+                                <span>
+                                    <strong>Shadow Techniques</strong>
+                                    <small>Auto attacks have a 30% chance to grant 1 combo point.</small>
+                                </span>
+                            </label>
                         </div>
-                        <div>
-                            <span class="label">Hits</span>
-                            <span id="hitCount">0</span>
+                    </section>
+                    <section class="panel-section">
+                        <h2>Combat Control</h2>
+                        <div class="control-buttons">
+                            <button type="button" id="arpg-startCombat" class="primary">Start Combat</button>
+                            <button type="button" id="arpg-stopCombat">Stop Combat</button>
+                            <button type="button" id="arpg-resetCombat">Reset</button>
                         </div>
-                        <div>
-                            <span class="label">Crits</span>
-                            <span id="critCount">0</span>
-                        </div>
-                    </div>
-                </section>
-
-                <section class="panel-section">
-                    <h2>Ability Breakdown</h2>
-                    <div class="ability-breakdown">
-                        <div class="breakdown-header">
-                            <span>Ability</span>
-                            <span>Uses</span>
-                            <span>Damage</span>
-                            <span>Share</span>
-                        </div>
-                        <div id="abilityBreakdownList" class="breakdown-list"></div>
-                    </div>
-                </section>
-
-                <section class="panel-section">
-                    <h2>Buffs & Debuffs</h2>
-                    <div class="buff-list" id="buffList"></div>
-                    <div class="debuff-list" id="debuffList"></div>
-                </section>
-            </aside>
+                    </section>
+                    <section class="panel-section">
+                        <h2>Combat Procs</h2>
+                        <div id="arpg-procConfig" class="proc-config"></div>
+                    </section>
+                </aside>
+            </div>
+            <div class="panel arpg-combat-log-window" id="arpg-combatLogWindow">
+                <div class="drag-handle" id="arpg-combatLogHandle">Combat Log</div>
+                <div class="combat-log" id="arpg-combatLog"></div>
+            </div>
         </div>
     </div>
 
     <div id="tooltip" class="ability-tooltip" hidden>
+        <h3></h3>
+        <p></p>
+        <span class="tooltip-hotkey"></span>
+    </div>
+
+    <div id="arpg-tooltip" class="ability-tooltip" hidden>
         <h3></h3>
         <p></p>
         <span class="tooltip-hotkey"></span>

--- a/index.ts
+++ b/index.ts
@@ -140,6 +140,16 @@ class Ability {
     }
 }
 
+interface CombatTargetAdapter {
+    getCurrentHealth(): number;
+    getMaxHealth(): number;
+    applyDamage(amount: number, payload: { ability?: Ability | { name: string; id: string }; isCrit?: boolean; isAuto?: boolean; isDot?: boolean }): void;
+    onCombatStart?(): void;
+    onCombatEnd?(): void;
+    onReset?(): void;
+    onDefeated?(): void;
+}
+
 class SoundPlayer {
     // Fix: Declare class property.
     context: AudioContext | null;
@@ -495,65 +505,77 @@ class UIController {
     }>;
     procConfigContainer: HTMLElement;
     hotkeyMap?: Map<string, string>;
+    idPrefix: string;
+    abilityInterceptor: ((abilityId: string) => boolean | void) | null;
+    keyHandler?: (event: KeyboardEvent) => void;
 
-    constructor() {
-        // Fix: Use non-null assertions and type casting for element lookups.
-        this.elements = {
-            dummyHealthBar: document.getElementById('dummyHealthBar')!,
-            dummyHealthText: document.getElementById('dummyHealthText')!,
-            dummyModel: document.getElementById('dummyModel')!,
-            energyBar: document.getElementById('energyBar')!,
-            energyText: document.getElementById('energyText')!,
-            comboPoints: Array.from(document.querySelectorAll('#comboPoints .combo-point')) as HTMLElement[],
-            buffTimers: document.getElementById('buffTimers')!,
-            buffList: document.getElementById('buffList')!,
-            debuffList: document.getElementById('debuffList')!,
-            combatLog: document.getElementById('combatLog')!,
-            actionBar: document.getElementById('actionBar')!,
-            floatingTextContainer: document.getElementById('floatingTextContainer')!,
-            currentDPS: document.getElementById('currentDPS')!,
-            totalDamage: document.getElementById('totalDamage')!,
-            averageDPS: document.getElementById('averageDPS')!,
-            hitCount: document.getElementById('hitCount')!,
-            critCount: document.getElementById('critCount')!,
-            abilityBreakdownList: document.getElementById('abilityBreakdownList')!,
-            forecast1: document.getElementById('forecast1')!,
-            forecast3: document.getElementById('forecast3')!,
-            forecast5: document.getElementById('forecast5')!,
-            combatTimer: document.getElementById('combatTimer')!,
-            previousDps: document.getElementById('previousDps')!,
-            currentDpsCompare: document.getElementById('currentDpsCompare')!,
-            dpsDelta: document.getElementById('dpsDelta')!,
-            dpsGraph: document.getElementById('dpsGraph') as HTMLCanvasElement,
+    constructor(options: { idPrefix?: string } = {}) {
+        this.idPrefix = options.idPrefix ?? '';
+        const resolveId = (id: string) => (this.idPrefix ? `${this.idPrefix}-${id}` : id);
+        const requireElement = <T extends HTMLElement>(id: string): T => {
+            const element = document.getElementById(resolveId(id));
+            if (!element) {
+                throw new Error(`Missing UI element: ${resolveId(id)}`);
+            }
+            return element as T;
         };
 
-        this.tooltip = document.getElementById('tooltip')!;
+        this.elements = {
+            dummyHealthBar: requireElement('dummyHealthBar'),
+            dummyHealthText: requireElement('dummyHealthText'),
+            dummyModel: requireElement('dummyModel'),
+            energyBar: requireElement('energyBar'),
+            energyText: requireElement('energyText'),
+            comboPoints: Array.from(requireElement('comboPoints').querySelectorAll('.combo-point')) as HTMLElement[],
+            buffTimers: requireElement('buffTimers'),
+            buffList: requireElement('buffList'),
+            debuffList: requireElement('debuffList'),
+            combatLog: requireElement('combatLog'),
+            actionBar: requireElement('actionBar'),
+            floatingTextContainer: requireElement('floatingTextContainer'),
+            currentDPS: requireElement('currentDPS'),
+            totalDamage: requireElement('totalDamage'),
+            averageDPS: requireElement('averageDPS'),
+            hitCount: requireElement('hitCount'),
+            critCount: requireElement('critCount'),
+            abilityBreakdownList: requireElement('abilityBreakdownList'),
+            forecast1: requireElement('forecast1'),
+            forecast3: requireElement('forecast3'),
+            forecast5: requireElement('forecast5'),
+            combatTimer: requireElement('combatTimer'),
+            previousDps: requireElement('previousDps'),
+            currentDpsCompare: requireElement('currentDpsCompare'),
+            dpsDelta: requireElement('dpsDelta'),
+            dpsGraph: requireElement('dpsGraph') as HTMLCanvasElement,
+        };
+
+        this.tooltip = requireElement('tooltip');
         this.forms = {
-            attackPower: document.getElementById('attackPower') as HTMLInputElement,
-            weaponMin: document.getElementById('weaponMin') as HTMLInputElement,
-            weaponMax: document.getElementById('weaponMax') as HTMLInputElement,
-            critChance: document.getElementById('critChance') as HTMLInputElement,
-            hitChance: document.getElementById('hitChance') as HTMLInputElement,
-            maxEnergy: document.getElementById('maxEnergy') as HTMLInputElement,
-            tickInterval: document.getElementById('tickInterval') as HTMLInputElement,
-            energyPerTick: document.getElementById('energyPerTick') as HTMLInputElement,
-            talentBonus: document.getElementById('talentBonus') as HTMLInputElement,
-            talentPrecision: document.getElementById('talentPrecision') as HTMLInputElement,
-            talentRelentless: document.getElementById('talentRelentless') as HTMLInputElement,
-            talentShadowTechniques: document.getElementById('talentShadowTechniques') as HTMLInputElement,
+            attackPower: requireElement('attackPower') as HTMLInputElement,
+            weaponMin: requireElement('weaponMin') as HTMLInputElement,
+            weaponMax: requireElement('weaponMax') as HTMLInputElement,
+            critChance: requireElement('critChance') as HTMLInputElement,
+            hitChance: requireElement('hitChance') as HTMLInputElement,
+            maxEnergy: requireElement('maxEnergy') as HTMLInputElement,
+            tickInterval: requireElement('tickInterval') as HTMLInputElement,
+            energyPerTick: requireElement('energyPerTick') as HTMLInputElement,
+            talentBonus: requireElement('talentBonus') as HTMLInputElement,
+            talentPrecision: requireElement('talentPrecision') as HTMLInputElement,
+            talentRelentless: requireElement('talentRelentless') as HTMLInputElement,
+            talentShadowTechniques: requireElement('talentShadowTechniques') as HTMLInputElement,
         };
 
         this.buttons = {
-            startCombat: document.getElementById('startCombat') as HTMLButtonElement,
-            stopCombat: document.getElementById('stopCombat') as HTMLButtonElement,
-            resetCombat: document.getElementById('resetCombat') as HTMLButtonElement,
+            startCombat: requireElement('startCombat') as HTMLButtonElement,
+            stopCombat: requireElement('stopCombat') as HTMLButtonElement,
+            resetCombat: requireElement('resetCombat') as HTMLButtonElement,
         };
 
-        /** @type {RogueSimulator | null} */
         this.simulator = null;
         this.soundPlayer = new SoundPlayer();
         this.procInputs = new Map();
-        this.procConfigContainer = document.getElementById('procConfig')!;
+        this.procConfigContainer = requireElement('procConfig');
+        this.abilityInterceptor = null;
     }
 
     bindSimulator(simulator: RogueSimulator) {
@@ -666,11 +688,25 @@ class UIController {
                 <span>${ability.icon}</span>
                 <span class="ability-hotkey">${ability.hotkey}</span>
             `;
-            button.addEventListener('click', () => this.simulator?.castAbility(ability.id));
+            button.addEventListener('click', () => this.useAbility(ability.id));
             button.addEventListener('mouseenter', (event) => this.showTooltip(event, ability));
             button.addEventListener('mouseleave', () => this.hideTooltip());
             this.elements.actionBar.appendChild(button);
         });
+    }
+
+    setAbilityInterceptor(handler: ((abilityId: string) => boolean | void) | null) {
+        this.abilityInterceptor = handler;
+    }
+
+    private useAbility(abilityId: string) {
+        if (this.abilityInterceptor) {
+            const result = this.abilityInterceptor(abilityId);
+            if (result === false) {
+                return;
+            }
+        }
+        this.simulator?.castAbility(abilityId);
     }
 
     showTooltip(event: MouseEvent, ability: Ability) {
@@ -1031,7 +1067,8 @@ class UIController {
     }
 
     attachHotkeyListeners() {
-        document.addEventListener('keydown', (event) => {
+        if (this.keyHandler) return;
+        this.keyHandler = (event: KeyboardEvent) => {
             if (event.repeat) return;
             const target = event.target;
             // Fix: Check if target is an HTMLElement to access properties like isContentEditable.
@@ -1051,9 +1088,814 @@ class UIController {
             const abilityId = this.hotkeyMap?.get(event.key.toLowerCase());
             if (abilityId) {
                 event.preventDefault();
-                this.simulator?.castAbility(abilityId);
+                this.useAbility(abilityId);
+            }
+        };
+        document.addEventListener('keydown', this.keyHandler);
+    }
+
+    detachHotkeyListeners() {
+        if (!this.keyHandler) return;
+        document.removeEventListener('keydown', this.keyHandler);
+        this.keyHandler = undefined;
+    }
+}
+
+type WorldProjector = (entity: 'player' | 'target') => { x: number; y: number } | null;
+interface TargetInfo {
+    id: string;
+    name: string;
+    health: number;
+    maxHealth: number;
+}
+
+class ActionRpgUIController extends UIController {
+    game: ActionRpgGame | null;
+    minimapCanvas: HTMLCanvasElement | null;
+    minimapCtx: CanvasRenderingContext2D | null;
+    targetName: HTMLElement;
+    targetFrame: HTMLElement;
+    rangeWarning: HTMLElement;
+    playerBuffContainer: HTMLElement;
+    dpsMeterValue: HTMLElement;
+    worldProjector: WorldProjector | null;
+    combatLogWindow: HTMLElement | null;
+    combatLogHandle: HTMLElement | null;
+    dragState: { active: boolean; offsetX: number; offsetY: number };
+
+    constructor() {
+        super({ idPrefix: 'arpg' });
+        this.game = null;
+        this.minimapCanvas = document.getElementById('arpg-minimap') as HTMLCanvasElement | null;
+        this.minimapCtx = this.minimapCanvas ? this.minimapCanvas.getContext('2d') : null;
+        this.targetName = document.getElementById('arpg-targetName')!;
+        this.targetFrame = document.getElementById('arpg-targetFrame')!;
+        this.rangeWarning = document.getElementById('arpg-rangeWarning')!;
+        this.playerBuffContainer = document.getElementById('arpg-playerBuffs')!;
+        this.dpsMeterValue = document.getElementById('arpg-currentDPS')!;
+        this.worldProjector = null;
+        this.combatLogWindow = document.getElementById('arpg-combatLogWindow');
+        this.combatLogHandle = document.getElementById('arpg-combatLogHandle');
+        this.dragState = { active: false, offsetX: 0, offsetY: 0 };
+        this.enableDrag();
+    }
+
+    setGame(game: ActionRpgGame) {
+        this.game = game;
+    }
+
+    setWorldProjector(projector: WorldProjector | null) {
+        this.worldProjector = projector;
+    }
+
+    getMinimapContext() {
+        return this.minimapCtx;
+    }
+
+    updateActionBarPosition(x: number, y: number) {
+        const bar = this.elements.actionBar;
+        bar.style.left = `${x}px`;
+        bar.style.top = `${y}px`;
+    }
+
+    updateTargetFrame(info: TargetInfo | null) {
+        if (!info) {
+            this.targetFrame.classList.add('hidden');
+            this.targetName.textContent = 'No Target';
+            return;
+        }
+        this.targetFrame.classList.remove('hidden');
+        this.targetName.textContent = info.name;
+    }
+
+    showRangeWarning(message: string) {
+        if (!message) {
+            this.rangeWarning.classList.remove('visible');
+            this.rangeWarning.textContent = '';
+        } else {
+            this.rangeWarning.classList.add('visible');
+            this.rangeWarning.textContent = message;
+        }
+    }
+
+    updateDpsMeter(value: number) {
+        this.dpsMeterValue.textContent = value.toFixed(1);
+    }
+
+    override updateBuffTimers(buffValues: any[], debuffValues: any[]) {
+        super.updateBuffTimers(buffValues, debuffValues);
+        const container = this.playerBuffContainer;
+        container.innerHTML = '';
+        [...buffValues, ...debuffValues].forEach(effect => {
+            const node = document.createElement('div');
+            node.className = `player-buff ${effect.type === 'debuff' ? 'debuff' : ''}`;
+            node.textContent = `${effect.icon ?? ''}`;
+            node.title = `${effect.name} (${effect.remaining.toFixed(1)}s)`;
+            container.appendChild(node);
+        });
+    }
+
+    override flashDummy() {
+        this.soundPlayer.playHit();
+        this.game?.flashTarget();
+    }
+
+    override showDamageNumber(damage: number, { isCrit = false, isAuto = false }: { isCrit?: boolean; isAuto?: boolean; }) {
+        const container = this.elements.floatingTextContainer;
+        if (!container) return;
+
+        const node = document.createElement('div');
+        node.className = 'damage-number anchored';
+        if (isCrit) node.classList.add('crit');
+        if (isAuto) node.classList.add('auto');
+        node.textContent = String(Math.floor(damage));
+
+        const anchor = this.worldProjector?.('target');
+        if (anchor) {
+            node.style.left = `${anchor.x}px`;
+            node.style.top = `${anchor.y}px`;
+        }
+        container.appendChild(node);
+        setTimeout(() => node.remove(), 1600);
+    }
+
+    override showFloatingText(message: string, type = 'proc') {
+        const container = this.elements.floatingTextContainer;
+        if (!container) return;
+        const node = document.createElement('div');
+        node.className = `floating-text anchored ${type}`;
+        node.textContent = message;
+        const anchor = this.worldProjector?.('player');
+        if (anchor) {
+            node.style.left = `${anchor.x}px`;
+            node.style.top = `${anchor.y}px`;
+        }
+        container.appendChild(node);
+        setTimeout(() => node.remove(), 1200);
+    }
+
+    override updateResources(state: RogueState) {
+        super.updateResources(state);
+        this.updateDpsMeter(this.game ? this.game.getCurrentDps() : 0);
+    }
+
+    enableDrag() {
+        if (!this.combatLogWindow || !this.combatLogHandle) return;
+        const windowEl = this.combatLogWindow;
+        const handle = this.combatLogHandle;
+
+        const onMouseMove = (event: MouseEvent) => {
+            if (!this.dragState.active) return;
+            windowEl.style.left = `${event.clientX - this.dragState.offsetX}px`;
+            windowEl.style.top = `${event.clientY - this.dragState.offsetY}px`;
+        };
+
+        const onMouseUp = () => {
+            this.dragState.active = false;
+            document.removeEventListener('mousemove', onMouseMove);
+            document.removeEventListener('mouseup', onMouseUp);
+        };
+
+        handle.addEventListener('mousedown', (event) => {
+            this.dragState.active = true;
+            const rect = windowEl.getBoundingClientRect();
+            this.dragState.offsetX = event.clientX - rect.left;
+            this.dragState.offsetY = event.clientY - rect.top;
+            document.addEventListener('mousemove', onMouseMove);
+            document.addEventListener('mouseup', onMouseUp);
+        });
+    }
+}
+
+type EntityKind = 'player' | 'dummy' | 'enemy' | 'npc' | 'loot';
+
+interface WorldEntity {
+    id: string;
+    kind: EntityKind;
+    x: number;
+    y: number;
+}
+
+interface DummyEntity extends WorldEntity {
+    kind: 'dummy';
+    name: string;
+    radius: number;
+    maxHealth: number;
+    health: number;
+    respawnTimer: number;
+    highlight: number;
+}
+
+class EntityCollection<T extends WorldEntity> {
+    private items: Map<string, T>;
+
+    constructor(initial?: T[]) {
+        this.items = new Map();
+        initial?.forEach(entity => this.add(entity));
+    }
+
+    add(entity: T) {
+        this.items.set(entity.id, entity);
+    }
+
+    remove(id: string) {
+        this.items.delete(id);
+    }
+
+    getById(id: string) {
+        return this.items.get(id) ?? null;
+    }
+
+    first(predicate?: (entity: T) => boolean) {
+        if (!predicate) {
+            for (const entity of this.items.values()) {
+                return entity;
+            }
+            return null;
+        }
+        for (const entity of this.items.values()) {
+            if (predicate(entity)) {
+                return entity;
+            }
+        }
+        return null;
+    }
+
+    forEach(callback: (entity: T) => void) {
+        this.items.forEach(entity => callback(entity));
+    }
+
+    map<R>(callback: (entity: T) => R) {
+        return Array.from(this.items.values(), callback);
+    }
+
+    filter(predicate: (entity: T) => boolean) {
+        const results: T[] = [];
+        this.items.forEach(entity => {
+            if (predicate(entity)) {
+                results.push(entity);
             }
         });
+        return results;
+    }
+
+    find(predicate: (entity: T) => boolean) {
+        for (const entity of this.items.values()) {
+            if (predicate(entity)) {
+                return entity;
+            }
+        }
+        return null;
+    }
+
+    toArray() {
+        return Array.from(this.items.values());
+    }
+
+    get size() {
+        return this.items.size;
+    }
+
+    [Symbol.iterator]() {
+        return this.items.values();
+    }
+}
+
+class ActionRpgGame {
+    canvas: HTMLCanvasElement;
+    ctx: CanvasRenderingContext2D;
+    ui: ActionRpgUIController;
+    simulator: RogueSimulator;
+    tileSize: number;
+    map: number[][];
+    keys: Set<string>;
+    player: {
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+        baseSpeed: number;
+        sprintSpeed: number;
+        animationTimer: number;
+        animationFrame: number;
+        facing: 'left' | 'right';
+        stealth: boolean;
+    };
+    camera: { x: number; y: number };
+    dummies: EntityCollection<DummyEntity>;
+    adapters: Map<string, CombatTargetAdapter>;
+    currentTarget: DummyEntity | null;
+    meleeRange: number;
+    running: boolean;
+    loopHandle: number | null;
+    lastTimestamp: number;
+    sprintEnergyCost: number;
+
+    constructor(canvas: HTMLCanvasElement, ui: ActionRpgUIController, simulator: RogueSimulator) {
+        const ctx = canvas.getContext('2d');
+        if (!ctx) {
+            throw new Error('Canvas 2D context unavailable for ARPG mode');
+        }
+        this.canvas = canvas;
+        this.ctx = ctx;
+        this.ui = ui;
+        this.simulator = simulator;
+        this.tileSize = 64;
+        this.map = this.createMap();
+        this.keys = new Set();
+        this.player = {
+            x: this.tileSize * 3,
+            y: this.tileSize * 3,
+            width: 42,
+            height: 56,
+            baseSpeed: 160,
+            sprintSpeed: 240,
+            animationTimer: 0,
+            animationFrame: 0,
+            facing: 'right',
+            stealth: false,
+        };
+        this.camera = { x: this.player.x, y: this.player.y };
+        this.dummies = new EntityCollection(this.createDummies());
+        this.adapters = new Map();
+        this.currentTarget = this.dummies.first() ?? null;
+        this.meleeRange = 110;
+        this.running = false;
+        this.loopHandle = null;
+        this.lastTimestamp = performance.now();
+        this.sprintEnergyCost = 18;
+
+        this.ui.setGame(this);
+        this.ui.setWorldProjector((entity) => this.getAnchor(entity));
+        this.ui.setAbilityInterceptor((abilityId) => this.handleAbilityIntercept(abilityId));
+        this.ui.updateTargetFrame(this.currentTarget ? this.getTargetInfo(this.currentTarget) : null);
+        if (this.currentTarget) {
+            this.simulator.setExternalTarget(this.getAdapter(this.currentTarget));
+        }
+    }
+
+    getCurrentDps() {
+        return this.simulator.getCurrentDps();
+    }
+
+    start() {
+        if (this.running) return;
+        this.running = true;
+        this.bindInput();
+        this.lastTimestamp = performance.now();
+        this.loopHandle = requestAnimationFrame(this.tick);
+    }
+
+    stop() {
+        if (!this.running) return;
+        this.running = false;
+        if (this.loopHandle !== null) {
+            cancelAnimationFrame(this.loopHandle);
+            this.loopHandle = null;
+        }
+        this.unbindInput();
+    }
+
+    destroy() {
+        this.stop();
+        this.ui.setAbilityInterceptor(null);
+        this.ui.setWorldProjector(null);
+    }
+
+    private tick = (timestamp: number) => {
+        if (!this.running) return;
+        const delta = (timestamp - this.lastTimestamp) / 1000;
+        this.lastTimestamp = timestamp;
+        this.update(delta);
+        this.render();
+        this.loopHandle = requestAnimationFrame(this.tick);
+    };
+
+    private update(delta: number) {
+        this.updatePlayer(delta);
+        this.updateDummies(delta);
+        this.updateCamera();
+        this.updateActionBar();
+        this.drawMinimap();
+    }
+
+    private updatePlayer(delta: number) {
+        const speed = this.getMovementSpeed(delta);
+        let moveX = 0;
+        let moveY = 0;
+        if (this.keys.has('KeyW')) moveY -= 1;
+        if (this.keys.has('KeyS')) moveY += 1;
+        if (this.keys.has('KeyA')) {
+            moveX -= 1;
+            this.player.facing = 'left';
+        }
+        if (this.keys.has('KeyD')) {
+            moveX += 1;
+            this.player.facing = 'right';
+        }
+
+        const magnitude = Math.hypot(moveX, moveY);
+        if (magnitude > 0) {
+            moveX /= magnitude;
+            moveY /= magnitude;
+            this.player.animationTimer += delta;
+            if (this.player.animationTimer >= 0.15) {
+                this.player.animationTimer = 0;
+                this.player.animationFrame = (this.player.animationFrame + 1) % 2;
+            }
+        } else {
+            this.player.animationFrame = 0;
+            this.player.animationTimer = 0;
+        }
+
+        this.tryMove(moveX * speed * delta, moveY * speed * delta);
+    }
+
+    private getMovementSpeed(delta: number) {
+        const sprinting = this.keys.has('ShiftLeft') || this.keys.has('ShiftRight');
+        if (sprinting && this.simulator.state.energy > 0) {
+            const cost = this.sprintEnergyCost * delta;
+            this.simulator.spendEnergy(cost);
+            return this.player.sprintSpeed;
+        }
+        return this.player.baseSpeed;
+    }
+
+    private tryMove(dx: number, dy: number) {
+        const nextX = this.player.x + dx;
+        const nextY = this.player.y + dy;
+        if (this.isWalkable(nextX, this.player.y, this.player.width, this.player.height)) {
+            this.player.x = nextX;
+        }
+        if (this.isWalkable(this.player.x, nextY, this.player.width, this.player.height)) {
+            this.player.y = nextY;
+        }
+    }
+
+    private isWalkable(x: number, y: number, width: number, height: number) {
+        const halfW = width / 2;
+        const halfH = height / 2;
+        const bounds = [
+            { x: x - halfW, y: y - halfH },
+            { x: x + halfW, y: y - halfH },
+            { x: x - halfW, y: y + halfH },
+            { x: x + halfW, y: y + halfH },
+        ];
+        return bounds.every(point => this.isTileWalkable(point.x, point.y));
+    }
+
+    private isTileWalkable(x: number, y: number) {
+        if (x < 0 || y < 0) return false;
+        const tileX = Math.floor(x / this.tileSize);
+        const tileY = Math.floor(y / this.tileSize);
+        if (tileY < 0 || tileY >= this.map.length) return false;
+        if (tileX < 0 || tileX >= this.map[0].length) return false;
+        const tile = this.map[tileY][tileX];
+        return tile !== 2;
+    }
+
+    private updateDummies(delta: number) {
+        this.dummies.forEach(dummy => {
+            if (dummy.health <= 0) {
+                dummy.respawnTimer -= delta;
+                if (dummy.respawnTimer <= 0) {
+                    dummy.health = dummy.maxHealth;
+                    dummy.respawnTimer = 0;
+                    if (dummy === this.currentTarget) {
+                        this.simulator.setExternalTarget(this.getAdapter(dummy));
+                    }
+                }
+            }
+            if (dummy.highlight > 0) {
+                dummy.highlight = Math.max(0, dummy.highlight - delta * 3);
+            }
+        });
+    }
+
+    private updateCamera() {
+        const halfWidth = this.canvas.width / 2;
+        const halfHeight = this.canvas.height / 2;
+        const mapWidth = this.map[0].length * this.tileSize;
+        const mapHeight = this.map.length * this.tileSize;
+        const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+        this.camera.x = clamp(this.player.x, halfWidth, mapWidth - halfWidth);
+        this.camera.y = clamp(this.player.y, halfHeight, mapHeight - halfHeight);
+    }
+
+    private updateActionBar() {
+        const playerScreen = this.worldToScreen(this.player.x, this.player.y);
+        this.ui.updateActionBarPosition(playerScreen.x - 160, playerScreen.y + 60);
+    }
+
+    private drawMinimap() {
+        const ctx = this.ui.getMinimapContext();
+        const canvas = this.ui.minimapCanvas;
+        if (!ctx || !canvas) return;
+        const scaleX = canvas.width / (this.map[0].length * this.tileSize);
+        const scaleY = canvas.height / (this.map.length * this.tileSize);
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.fillStyle = '#1f1f24';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        this.map.forEach((row, y) => {
+            row.forEach((tile, x) => {
+                if (tile === 2) {
+                    ctx.fillStyle = '#2c2f3a';
+                } else if (tile === 1) {
+                    ctx.fillStyle = '#1b412f';
+                } else {
+                    ctx.fillStyle = '#304a73';
+                }
+                ctx.fillRect(x * this.tileSize * scaleX, y * this.tileSize * scaleY, this.tileSize * scaleX, this.tileSize * scaleY);
+            });
+        });
+        ctx.fillStyle = '#ffd166';
+        ctx.beginPath();
+        ctx.arc(this.player.x * scaleX, this.player.y * scaleY, 6, 0, Math.PI * 2);
+        ctx.fill();
+        this.dummies.forEach(dummy => {
+            ctx.fillStyle = dummy === this.currentTarget ? '#ef476f' : '#06d6a0';
+            ctx.beginPath();
+            ctx.arc(dummy.x * scaleX, dummy.y * scaleY, 5, 0, Math.PI * 2);
+            ctx.fill();
+        });
+    }
+
+    private render() {
+        this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+        this.drawTiles();
+        this.drawDummies();
+        this.drawPlayer();
+    }
+
+    private drawTiles() {
+        for (let y = 0; y < this.map.length; y++) {
+            for (let x = 0; x < this.map[y].length; x++) {
+                const tile = this.map[y][x];
+                const screen = this.worldToScreen((x + 0.5) * this.tileSize, (y + 0.5) * this.tileSize);
+                const drawX = screen.x - this.tileSize / 2;
+                const drawY = screen.y - this.tileSize / 2;
+                if (tile === 2) {
+                    this.ctx.fillStyle = '#1d1e26';
+                } else if (tile === 1) {
+                    this.ctx.fillStyle = '#283845';
+                } else {
+                    this.ctx.fillStyle = '#1f2933';
+                }
+                this.ctx.fillRect(drawX, drawY, this.tileSize, this.tileSize);
+            }
+        }
+    }
+
+    private drawDummies() {
+        this.dummies.forEach(dummy => {
+            const screen = this.worldToScreen(dummy.x, dummy.y);
+            const radius = dummy.radius;
+            if (dummy.health <= 0) {
+                this.ctx.globalAlpha = 0.35;
+            }
+            this.ctx.fillStyle = '#7c4dff';
+            this.ctx.beginPath();
+            this.ctx.arc(screen.x, screen.y, radius, 0, Math.PI * 2);
+            this.ctx.fill();
+            if (dummy.highlight > 0) {
+                this.ctx.strokeStyle = `rgba(255,255,255,${dummy.highlight})`;
+                this.ctx.lineWidth = 4;
+                this.ctx.beginPath();
+                this.ctx.arc(screen.x, screen.y, radius + 4, 0, Math.PI * 2);
+                this.ctx.stroke();
+            }
+            this.ctx.globalAlpha = 1;
+
+            // HP bar
+            const barWidth = radius * 2;
+            const barHeight = 6;
+            const healthPercent = Math.max(0, dummy.health / dummy.maxHealth);
+            this.ctx.fillStyle = '#1f1f1f';
+            this.ctx.fillRect(screen.x - radius, screen.y - radius - 16, barWidth, barHeight);
+            this.ctx.fillStyle = '#06d6a0';
+            this.ctx.fillRect(screen.x - radius, screen.y - radius - 16, barWidth * healthPercent, barHeight);
+            if (dummy === this.currentTarget) {
+                this.ctx.strokeStyle = '#ffd166';
+                this.ctx.lineWidth = 2;
+                this.ctx.strokeRect(screen.x - radius - 4, screen.y - radius - 20, barWidth + 8, barHeight + 8);
+            }
+        });
+    }
+
+    private drawPlayer() {
+        const screen = this.worldToScreen(this.player.x, this.player.y);
+        this.ctx.save();
+        if (this.player.stealth) {
+            this.ctx.globalAlpha = 0.55;
+        }
+        this.ctx.translate(screen.x, screen.y);
+        if (this.player.facing === 'left') {
+            this.ctx.scale(-1, 1);
+        }
+        this.ctx.fillStyle = '#ef476f';
+        const frameOffset = this.player.animationFrame === 0 ? 0 : 4;
+        this.ctx.fillRect(-this.player.width / 2, -this.player.height / 2 - frameOffset, this.player.width, this.player.height);
+        this.ctx.fillStyle = '#ffd166';
+        this.ctx.fillRect(-8, -this.player.height / 2 - frameOffset - 6, 16, 16);
+        this.ctx.restore();
+        this.ctx.globalAlpha = 1;
+    }
+
+    flashTarget() {
+        if (!this.currentTarget) return;
+        this.currentTarget.highlight = 1;
+    }
+
+    private createMap() {
+        const rows = 18;
+        const cols = 24;
+        const layout: number[][] = [];
+        for (let y = 0; y < rows; y++) {
+            const row: number[] = [];
+            for (let x = 0; x < cols; x++) {
+                if (x === 0 || y === 0 || x === cols - 1 || y === rows - 1) {
+                    row.push(2); // wall
+                } else {
+                    row.push(0);
+                }
+            }
+            layout.push(row);
+        }
+
+        // Create simple rooms and corridors
+        const carveRoom = (startX: number, startY: number, w: number, h: number) => {
+            for (let y = startY; y < startY + h; y++) {
+                for (let x = startX; x < startX + w; x++) {
+                    if (x > 0 && y > 0 && x < cols - 1 && y < rows - 1) {
+                        layout[y][x] = 1;
+                    }
+                }
+            }
+        };
+        carveRoom(2, 2, 7, 6);
+        carveRoom(10, 2, 8, 6);
+        carveRoom(5, 10, 12, 6);
+        // Corridors
+        for (let x = 7; x < 17; x++) layout[7][x] = 1;
+        for (let y = 7; y < 13; y++) layout[y][7] = 1;
+        return layout;
+    }
+
+    private createDummies(): DummyEntity[] {
+        return [
+            { kind: 'dummy', id: 'dummy-1', name: 'Training Dummy Alpha', x: this.tileSize * 4, y: this.tileSize * 4, radius: 24, maxHealth: 15000, health: 15000, respawnTimer: 0, highlight: 0 },
+            { kind: 'dummy', id: 'dummy-2', name: 'Training Dummy Beta', x: this.tileSize * 12, y: this.tileSize * 4, radius: 24, maxHealth: 20000, health: 20000, respawnTimer: 0, highlight: 0 },
+            { kind: 'dummy', id: 'dummy-3', name: 'Training Dummy Gamma', x: this.tileSize * 9, y: this.tileSize * 12, radius: 24, maxHealth: 25000, health: 25000, respawnTimer: 0, highlight: 0 },
+        ];
+    }
+
+    private bindInput() {
+        window.addEventListener('keydown', this.onKeyDown);
+        window.addEventListener('keyup', this.onKeyUp);
+        this.canvas.addEventListener('click', this.onClick);
+    }
+
+    private unbindInput() {
+        window.removeEventListener('keydown', this.onKeyDown);
+        window.removeEventListener('keyup', this.onKeyUp);
+        this.canvas.removeEventListener('click', this.onClick);
+    }
+
+    private onKeyDown = (event: KeyboardEvent) => {
+        if (event.repeat) return;
+        if (event.code === 'Tab') {
+            event.preventDefault();
+            this.cycleTarget();
+            return;
+        }
+        if (event.code === 'KeyX') {
+            this.toggleStealth();
+            return;
+        }
+        this.keys.add(event.code);
+    };
+
+    private onKeyUp = (event: KeyboardEvent) => {
+        this.keys.delete(event.code);
+    };
+
+    private onClick = (event: MouseEvent) => {
+        const rect = this.canvas.getBoundingClientRect();
+        const x = event.clientX - rect.left;
+        const y = event.clientY - rect.top;
+        const world = this.screenToWorld(x, y);
+        const clicked = this.dummies.find(dummy => Math.hypot(dummy.x - world.x, dummy.y - world.y) <= dummy.radius + 6);
+        if (clicked) {
+            this.selectTarget(clicked);
+        } else {
+            this.selectTarget(null);
+        }
+    };
+
+    private toggleStealth() {
+        this.player.stealth = !this.player.stealth;
+        if (this.player.stealth) {
+            this.simulator.applyBuff({ id: 'stealth', name: 'Stealth', duration: Infinity, icon: '🕶️', type: 'buff' });
+        } else {
+            this.simulator.removeBuff('stealth');
+        }
+    }
+
+    private cycleTarget() {
+        if (this.dummies.size === 0) return;
+        const alive = this.dummies.filter(dummy => dummy.health > 0);
+        if (alive.length === 0) return;
+        const currentId = this.currentTarget?.id;
+        const currentIndex = currentId ? alive.findIndex(dummy => dummy.id === currentId) : 0;
+        const next = alive[(currentIndex + 1) % alive.length];
+        this.selectTarget(next);
+    }
+
+    private selectTarget(dummy: DummyEntity | null) {
+        this.currentTarget = dummy;
+        if (dummy) {
+            this.simulator.setExternalTarget(this.getAdapter(dummy));
+            this.ui.updateTargetFrame(this.getTargetInfo(dummy));
+        } else {
+            this.simulator.stopCombat();
+            this.simulator.setExternalTarget(null);
+            this.ui.updateTargetFrame(null);
+        }
+        this.ui.showRangeWarning('');
+    }
+
+    private handleAbilityIntercept(_abilityId: string) {
+        if (!this.currentTarget) {
+            this.ui.showRangeWarning('Kein Ziel ausgewählt');
+            return false;
+        }
+        if (this.currentTarget.health <= 0) {
+            this.ui.showRangeWarning('Ziel ist besiegt');
+            return false;
+        }
+        const distance = Math.hypot(this.player.x - this.currentTarget.x, this.player.y - this.currentTarget.y);
+        if (distance > this.meleeRange) {
+            this.ui.showRangeWarning('Außer Reichweite');
+            return false;
+        }
+        this.ui.showRangeWarning('');
+        return true;
+    }
+
+    private getAdapter(dummy: DummyEntity) {
+        let adapter = this.adapters.get(dummy.id);
+        if (!adapter) {
+            adapter = {
+                getCurrentHealth: () => dummy.health,
+                getMaxHealth: () => dummy.maxHealth,
+                applyDamage: (amount: number) => {
+                    dummy.health = Math.max(0, dummy.health - amount);
+                    dummy.highlight = 1;
+                    if (dummy.health <= 0) {
+                        dummy.respawnTimer = 5;
+                    }
+                },
+                onCombatStart: () => {},
+                onCombatEnd: () => {},
+                onReset: () => {
+                    dummy.health = dummy.maxHealth;
+                    dummy.respawnTimer = 0;
+                },
+                onDefeated: () => {},
+            };
+            this.adapters.set(dummy.id, adapter);
+        }
+        return adapter;
+    }
+
+    private getTargetInfo(dummy: DummyEntity): TargetInfo {
+        return { id: dummy.id, name: dummy.name, health: dummy.health, maxHealth: dummy.maxHealth };
+    }
+
+    private getAnchor(entity: 'player' | 'target') {
+        if (entity === 'player') {
+            const pos = this.worldToScreen(this.player.x, this.player.y - this.player.height / 2);
+            return { x: pos.x, y: pos.y - 40 };
+        }
+        if (entity === 'target' && this.currentTarget) {
+            const pos = this.worldToScreen(this.currentTarget.x, this.currentTarget.y - this.currentTarget.radius - 10);
+            return { x: pos.x, y: pos.y };
+        }
+        return null;
+    }
+
+    private worldToScreen(x: number, y: number) {
+        return {
+            x: Math.round((x - this.camera.x) + this.canvas.width / 2),
+            y: Math.round((y - this.camera.y) + this.canvas.height / 2),
+        };
+    }
+
+    private screenToWorld(x: number, y: number) {
+        return {
+            x: this.camera.x - this.canvas.width / 2 + x,
+            y: this.camera.y - this.canvas.height / 2 + y,
+        };
     }
 }
 
@@ -1070,9 +1912,13 @@ class RogueSimulator {
     sessionHistory: { damage: number; duration: number; dps: number; }[];
     currentSession: { damage: number; duration: number; dps: number; } | null;
     previousSession: { damage: number; duration: number; dps: number; } | null;
+    externalTarget: CombatTargetAdapter | null;
+    defaultDummyHealth: number;
 
     constructor(ui: UIController) {
         this.ui = ui;
+        this.externalTarget = null;
+        this.defaultDummyHealth = 1000000;
         this.state = {
             inCombat: false,
             energy: 100,
@@ -1080,8 +1926,8 @@ class RogueSimulator {
             comboPoints: 0,
             maxComboPoints: 5,
             globalCooldown: 0,
-            dummyMaxHealth: 1000000,
-            dummyHealth: 1000000,
+            dummyMaxHealth: this.defaultDummyHealth,
+            dummyHealth: this.defaultDummyHealth,
             autoAttackTimer: 2,
             baseAutoSpeed: 2,
             energyTickProgress: 0,
@@ -1123,8 +1969,19 @@ class RogueSimulator {
         this.sessionHistory = [];
         this.currentSession = null;
         this.previousSession = null;
-        
-        this.startLoop();
+
+        this.resume();
+    }
+
+    setExternalTarget(target: CombatTargetAdapter | null) {
+        this.externalTarget = target;
+        if (target) {
+            this.state.dummyMaxHealth = target.getMaxHealth();
+            this.state.dummyHealth = target.getCurrentHealth();
+        } else {
+            this.state.dummyMaxHealth = this.defaultDummyHealth;
+            this.state.dummyHealth = this.defaultDummyHealth;
+        }
     }
 
     getDefaultConfig(): RogueConfig {
@@ -1484,6 +2341,19 @@ class RogueSimulator {
         this.loopHandle = requestAnimationFrame(loop);
     }
 
+    pause() {
+        if (this.loopHandle !== null) {
+            cancelAnimationFrame(this.loopHandle);
+            this.loopHandle = null;
+        }
+    }
+
+    resume() {
+        if (this.loopHandle !== null) return;
+        this.lastTimestamp = performance.now();
+        this.startLoop();
+    }
+
     update(delta: number) {
         let remaining = Math.max(delta, 0);
         const maxStep = 0.5;
@@ -1549,7 +2419,13 @@ class RogueSimulator {
         this.state.stats.dpsHistory = [];
         this.state.comboPoints = 0;
         this.state.energy = this.state.maxEnergy;
-        this.state.dummyHealth = this.state.dummyMaxHealth;
+        if (this.externalTarget) {
+            this.externalTarget.onCombatStart?.();
+            this.state.dummyMaxHealth = this.externalTarget.getMaxHealth();
+            this.state.dummyHealth = this.externalTarget.getCurrentHealth();
+        } else {
+            this.state.dummyHealth = this.state.dummyMaxHealth;
+        }
         this.state.autoAttackTimer = this.state.baseAutoSpeed;
         this.state.energyTickProgress = 0;
         this.ui.addLogEntry('Combat started!', 'system');
@@ -1560,6 +2436,7 @@ class RogueSimulator {
         this.state.inCombat = false;
         this.state.globalCooldown = 0;
         this.clearEffects();
+        this.externalTarget?.onCombatEnd?.();
         const session = {
             damage: this.state.stats.totalDamage,
             duration: Math.max(this.state.stats.combatTime, 1),
@@ -1570,6 +2447,9 @@ class RogueSimulator {
         this.sessionHistory.push(session);
 
         this.ui.addLogEntry('Combat ended.', 'system');
+        if (!this.externalTarget) {
+            this.state.dummyHealth = this.state.dummyMaxHealth;
+        }
     }
 
     reset() {
@@ -1577,7 +2457,13 @@ class RogueSimulator {
         this.state.energy = this.state.maxEnergy;
         this.state.comboPoints = 0;
         this.state.globalCooldown = 0;
-        this.state.dummyHealth = this.state.dummyMaxHealth;
+        if (this.externalTarget) {
+            this.externalTarget.onReset?.();
+            this.state.dummyMaxHealth = this.externalTarget.getMaxHealth();
+            this.state.dummyHealth = this.externalTarget.getCurrentHealth();
+        } else {
+            this.state.dummyHealth = this.state.dummyMaxHealth;
+        }
         this.state.autoAttackTimer = this.state.baseAutoSpeed;
         this.state.energyTickProgress = 0;
         this.clearEffects();
@@ -1722,7 +2608,13 @@ class RogueSimulator {
     applyDamage(amount: number, { ability, isCrit = false, isAuto = false, isDot = false }: { ability?: Ability | { name: string, id: string }, isCrit?: boolean, isAuto?: boolean, isDot?: boolean } = {}) {
         const damage = Math.round(amount);
         if (damage <= 0) return;
-        this.state.dummyHealth = Math.max(0, this.state.dummyHealth - damage);
+        if (this.externalTarget) {
+            this.externalTarget.applyDamage(damage, { ability, isCrit, isAuto, isDot });
+            this.state.dummyMaxHealth = this.externalTarget.getMaxHealth();
+            this.state.dummyHealth = Math.max(0, this.externalTarget.getCurrentHealth());
+        } else {
+            this.state.dummyHealth = Math.max(0, this.state.dummyHealth - damage);
+        }
         this.state.stats.totalDamage += damage;
         this.state.stats.hitCount += 1;
         if (isCrit) this.state.stats.critCount += 1;
@@ -1740,9 +2632,15 @@ class RogueSimulator {
         }
         this.procSystem.handleEvent('damage', { ability, isCrit, isAuto, isDot, damage });
         if (this.state.dummyHealth <= 0) {
-            this.ui.addLogEntry('Dummy defeated!', 'system');
-            this.stopCombat();
-            this.state.dummyHealth = this.state.dummyMaxHealth;
+            if (this.externalTarget) {
+                this.ui.addLogEntry('Target defeated!', 'system');
+                this.externalTarget.onDefeated?.();
+                this.stopCombat();
+            } else {
+                this.ui.addLogEntry('Dummy defeated!', 'system');
+                this.stopCombat();
+                this.state.dummyHealth = this.state.dummyMaxHealth;
+            }
         }
     }
 
@@ -1870,6 +2768,14 @@ class RogueSimulator {
         enriched.onApply?.();
     }
 
+    removeBuff(id: string) {
+        const existing = this.state.buffs.get(id);
+        if (existing) {
+            existing.onExpire?.();
+            this.state.buffs.delete(id);
+        }
+    }
+
     applyDebuff(debuff: any) {
         if (this.state.debuffs.has(debuff.id)) {
             this.state.debuffs.get(debuff.id).onExpire?.();
@@ -1919,6 +2825,66 @@ class RogueSimulator {
     }
 }
 
-const ui = new UIController();
-const simulator = new RogueSimulator(ui);
-ui.bindSimulator(simulator);
+const simulatorUi = new UIController();
+const simulator = new RogueSimulator(simulatorUi);
+simulatorUi.bindSimulator(simulator);
+
+const arpgUi = new ActionRpgUIController();
+const arpgSimulator = new RogueSimulator(arpgUi);
+arpgUi.bindSimulator(arpgSimulator);
+arpgSimulator.pause();
+arpgUi.detachHotkeyListeners();
+
+const arpgCanvas = document.getElementById('arpg-canvas') as HTMLCanvasElement;
+const arpgGame = new ActionRpgGame(arpgCanvas, arpgUi, arpgSimulator);
+arpgGame.stop();
+
+const modeButtons = {
+    simulator: document.getElementById('switchSimulator') as HTMLButtonElement,
+    arpg: document.getElementById('switchArpg') as HTMLButtonElement,
+};
+const simulatorMode = document.getElementById('simulatorMode')!;
+const arpgMode = document.getElementById('arpgMode')!;
+let activeMode: 'simulator' | 'arpg' = 'simulator';
+
+function setActiveMode(mode: 'simulator' | 'arpg') {
+    if (mode === activeMode) return;
+    if (mode === 'simulator') {
+        document.body.classList.remove('mode-arpg');
+        document.body.classList.add('mode-simulator');
+        simulatorMode.classList.add('active');
+        arpgMode.classList.remove('active');
+        modeButtons.simulator.classList.add('active');
+        modeButtons.arpg.classList.remove('active');
+        arpgGame.stop();
+        arpgSimulator.removeBuff('stealth');
+        arpgGame.player.stealth = false;
+        arpgSimulator.pause();
+        arpgUi.detachHotkeyListeners();
+        arpgUi.showRangeWarning('');
+        simulator.resume();
+        simulatorUi.attachHotkeyListeners();
+    } else {
+        document.body.classList.remove('mode-simulator');
+        document.body.classList.add('mode-arpg');
+        simulatorMode.classList.remove('active');
+        arpgMode.classList.add('active');
+        modeButtons.simulator.classList.remove('active');
+        modeButtons.arpg.classList.add('active');
+        simulator.pause();
+        simulatorUi.detachHotkeyListeners();
+        arpgSimulator.resume();
+        arpgUi.attachHotkeyListeners();
+        arpgGame.start();
+    }
+    activeMode = mode;
+}
+
+modeButtons.simulator.addEventListener('click', () => setActiveMode('simulator'));
+modeButtons.arpg.addEventListener('click', () => setActiveMode('arpg'));
+
+document.body.classList.add('mode-simulator');
+simulatorMode.classList.add('active');
+arpgMode.classList.remove('active');
+modeButtons.simulator.classList.add('active');
+modeButtons.arpg.classList.remove('active');

--- a/style.css
+++ b/style.css
@@ -13,6 +13,45 @@ body {
     min-height: 100vh;
 }
 
+.mode-switcher {
+    display: flex;
+    justify-content: center;
+    gap: 14px;
+    margin-bottom: 24px;
+}
+
+.mode-button {
+    padding: 10px 22px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 215, 0, 0.35);
+    background: rgba(16, 24, 44, 0.8);
+    color: #f4f6fb;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-size: 0.82rem;
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+.mode-button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35);
+}
+
+.mode-button.active {
+    background: linear-gradient(120deg, rgba(255, 215, 0, 0.38), rgba(255, 191, 0, 0.2));
+    color: #080d1f;
+    box-shadow: 0 10px 22px rgba(255, 215, 0, 0.25);
+}
+
+.mode-view {
+    display: none;
+}
+
+.mode-view.active {
+    display: block;
+}
+
 .main-container {
     max-width: 1620px;
     margin: 0 auto;
@@ -807,6 +846,11 @@ body {
     color: #ff9dfc;
 }
 
+.floating-text.anchored {
+    left: auto;
+    transform: translate(-50%, -32px);
+}
+
 @keyframes floatUp {
     0% {
         opacity: 0;
@@ -838,6 +882,11 @@ body {
 
 .damage-number.auto {
     color: #f0f0f0; /* Auto-attack white */
+}
+
+.damage-number.anchored {
+    left: auto;
+    top: auto;
 }
 
 .damage-number.crit {
@@ -903,6 +952,199 @@ body {
     margin-top: 6px;
     font-size: 0.75rem;
     color: #ffd460;
+}
+
+.arpg-container {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    position: relative;
+}
+
+.arpg-main {
+    display: grid;
+    grid-template-columns: minmax(640px, 1fr) 320px;
+    gap: 24px;
+    align-items: flex-start;
+}
+
+.arpg-world {
+    position: relative;
+}
+
+.arpg-canvas-wrapper {
+    position: relative;
+    border-radius: 18px;
+    overflow: hidden;
+    border: 1px solid rgba(255, 215, 0, 0.16);
+    box-shadow: 0 20px 45px rgba(0, 0, 0, 0.45);
+    background: rgba(8, 12, 24, 0.82);
+}
+
+#arpg-canvas {
+    display: block;
+    width: 100%;
+    height: auto;
+    image-rendering: pixelated;
+}
+
+.arpg-overlay {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+}
+
+.arpg-player-hud {
+    position: absolute;
+    bottom: 32px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    pointer-events: none;
+}
+
+.arpg-player-hud .energy-bar-container {
+    width: 260px;
+    background: rgba(4, 9, 18, 0.8);
+    border-radius: 16px;
+    border: 1px solid rgba(255, 215, 0, 0.2);
+    overflow: hidden;
+}
+
+.player-buff-icons {
+    display: flex;
+    gap: 8px;
+}
+
+.player-buff {
+    width: 32px;
+    height: 32px;
+    border-radius: 6px;
+    background: rgba(255, 215, 0, 0.18);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1rem;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+}
+
+.player-buff.debuff {
+    background: rgba(255, 95, 95, 0.22);
+}
+
+.arpg-target-frame {
+    position: absolute;
+    top: 18px;
+    left: 24px;
+    min-width: 220px;
+    background: rgba(9, 13, 25, 0.78);
+    border-radius: 14px;
+    padding: 14px;
+    border: 1px solid rgba(255, 215, 0, 0.18);
+    box-shadow: 0 14px 28px rgba(0, 0, 0, 0.35);
+    pointer-events: none;
+}
+
+.arpg-target-frame.hidden {
+    opacity: 0.4;
+}
+
+.arpg-target-frame h3 {
+    font-size: 1rem;
+    color: #ffe17a;
+    margin-bottom: 10px;
+}
+
+.arpg-range-warning {
+    position: absolute;
+    top: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(255, 87, 87, 0.85);
+    color: #fff5f5;
+    padding: 6px 18px;
+    border-radius: 999px;
+    font-size: 0.82rem;
+    letter-spacing: 1px;
+    box-shadow: 0 12px 24px rgba(255, 87, 87, 0.2);
+    opacity: 0;
+    transition: opacity 0.2s ease;
+    pointer-events: none;
+}
+
+.arpg-range-warning.visible {
+    opacity: 1;
+}
+
+#arpg-minimap {
+    position: absolute;
+    top: 22px;
+    right: 24px;
+    width: 180px;
+    height: 180px;
+    background: rgba(7, 11, 23, 0.88);
+    border: 1px solid rgba(255, 215, 0, 0.2);
+    border-radius: 12px;
+    box-shadow: 0 10px 26px rgba(0, 0, 0, 0.4);
+}
+
+#arpg-actionBar {
+    position: absolute;
+    bottom: 14px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    gap: 8px;
+    pointer-events: auto;
+    background: rgba(10, 15, 30, 0.82);
+    padding: 10px 16px;
+    border-radius: 14px;
+    border: 1px solid rgba(255, 215, 0, 0.18);
+    box-shadow: 0 14px 32px rgba(0, 0, 0, 0.4);
+}
+
+.arpg-info-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.arpg-config-panel .panel-section + .panel-section {
+    margin-top: 20px;
+}
+
+.arpg-combat-log-window {
+    position: absolute;
+    bottom: 24px;
+    right: 24px;
+    width: 320px;
+    max-height: 260px;
+    pointer-events: auto;
+    z-index: 90;
+}
+
+.arpg-combat-log-window .combat-log {
+    max-height: 220px;
+    overflow-y: auto;
+}
+
+.arpg-combat-log-window .drag-handle {
+    cursor: grab;
+    padding: 8px 12px;
+    background: rgba(255, 215, 0, 0.16);
+    border-radius: 10px 10px 0 0;
+    text-align: center;
+    font-size: 0.8rem;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    margin: -20px -20px 12px;
+}
+
+.arpg-combat-log-window .drag-handle:active {
+    cursor: grabbing;
 }
 
 @media (max-width: 1280px) {


### PR DESCRIPTION
## Summary
- add a reusable `EntityCollection` to manage world entities in the ARPG scene and prepare for future NPC/enemy/loot systems
- migrate training dummies to the registry, tagging them with an explicit entity kind for reliable reuse and targeting

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db9d94ad448329bfcf3ca43761e173